### PR TITLE
tcp inflow: add pre-buffering

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -50,6 +50,7 @@ rustflags = [
     "-Aclippy::missing-panics-doc",
     "-Aclippy::similar-names",
     "-Aclippy::struct-field-names",
+    "-Aclippy::too-long-first-doc-paragraph",
     "-Aclippy::too-many-arguments",
     "-Aclippy::too-many-lines",
     "-Aclippy::unnecessary-wraps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arc-swap"
@@ -222,7 +222,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -250,9 +250,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ddc4a5b231dd6958b140ff3151b6412b3f4321fab354f399eec8f14b06df62"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
 dependencies = [
  "bindgen",
  "cc",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e88af26c1a077a59e1146c4bbb55d64cb84cb1a0dd14c7d40cc273e9292b43"
+checksum = "657982a9e70b8aa1b903c84f8e76c36202358c48f119330d5f4b74d7e6cf27b7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
+checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.45.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
+checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
+checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -521,7 +521,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -610,7 +610,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -664,10 +664,10 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
@@ -748,7 +748,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -814,7 +814,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "prometheus",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "color-backtrace",
  "log",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "log",
  "protobuf 4.0.0-alpha.0",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "base64ct",
  "itertools 0.13.0",
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime-config"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "async-trait",
  "bd-server-stats",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1070,7 +1070,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "log",
  "tokio",
@@ -1079,12 +1079,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#254e3360f31ebca0b2e452f7724e8f3e0b22be31"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#4f63c4e898283ee21d5ce1151ebb43964b9f8e16"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
@@ -1160,7 +1160,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.82",
  "which",
 ]
 
@@ -1241,15 +1241,15 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "syn_derive",
 ]
 
 [[package]]
 name = "built"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
 dependencies = [
  "git2",
 ]
@@ -1290,9 +1290,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytes-utils"
@@ -1321,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1528,7 +1528,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1853,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1897,7 +1897,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1908,7 +1908,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1962,17 +1962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,7 +1971,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2043,9 +2032,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "domain"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eefe29e8dd614abbee51a1616654cab123c4c56850ab83f5b7f1e1f9977bf7c"
+checksum = "64008666d9f3b6a88a63cd28ad8f3a5a859b8037e11bfb680c1b24945ea1c28d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2078,6 +2067,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,6 +2100,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2267,9 +2288,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2282,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2292,15 +2313,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2309,38 +2330,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2401,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -2684,9 +2705,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2708,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2737,7 +2758,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "pin-project-lite",
@@ -2755,7 +2776,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -2771,10 +2792,10 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -2789,7 +2810,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2807,7 +2828,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2962,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -3036,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3125,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa21063c854820a77c5d7f8deeb7ffa55246d8304e4bcd8cce2956752c6604f8"
+checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3138,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c2355f5c9d8a11900e71a6fe1e47abd5ec45bf971eb4b162ffe97b46db9bb7"
+checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3151,7 +3172,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-http-proxy",
  "hyper-rustls 0.27.3",
  "hyper-timeout",
@@ -3160,7 +3181,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -3169,16 +3190,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3030bd91c9db544a50247e7d48d7db9cf633c172732dce13351854526b1e666"
+checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -3194,29 +3215,29 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa98be978eddd70a773aa8e86346075365bfb7eb48783410852dbf7cb57f0c27"
+checksum = "f9364e04cc5e0482136c6ee8b7fb7551812da25802249f35b3def7aaa31e82ad"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5895cb8aa641ac922408f128b935652b34c2995f16ad7db0984f6caa50217914"
+checksum = "d3fbf1f6ffa98e65f1d2a9a69338bb60605d46be7edf00237784b89e62c9bd44"
 dependencies = [
  "ahash 0.8.11",
  "async-broadcast",
  "async-stream",
  "async-trait",
  "backoff",
- "derivative",
+ "educe",
  "futures",
  "hashbrown 0.14.5",
  "json-patch",
@@ -3277,9 +3298,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
@@ -3468,7 +3489,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3611,7 +3632,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3623,23 +3644,23 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "octseq"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed2eaec452d98ccc1c615dd843fd039d9445f2fb4da114ee7e6af5fcb68be98"
+checksum = "126c3ca37c9c44cec575247f43a3e4374d8927684f129d2beeb0d2cef262fe12"
 dependencies = [
  "bytes",
  "serde",
@@ -3657,12 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "onig"
@@ -3715,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -3802,9 +3820,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3813,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3823,22 +3841,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -3904,22 +3922,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3980,12 +3998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,12 +4056,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4106,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4187,7 +4199,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4343,7 +4355,7 @@ dependencies = [
  "protobuf-json-mapping",
  "pulse-protobuf",
  "reqwest",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "serde_json",
  "serde_yaml",
  "socket2",
@@ -4396,7 +4408,7 @@ dependencies = [
  "hashbrown 0.15.0",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "hyperloglogplus",
@@ -4601,7 +4613,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -4618,7 +4630,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4860,7 +4872,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -4871,7 +4883,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5027,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5099,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -5127,9 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -5157,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -5185,7 +5197,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5212,11 +5224,10 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -5269,9 +5280,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -5288,13 +5299,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5305,14 +5316,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -5497,7 +5508,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5566,7 +5577,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5588,9 +5599,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5606,7 +5617,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5687,22 +5698,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5813,9 +5824,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5838,7 +5849,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5857,7 +5868,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5943,7 +5954,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6005,6 +6016,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 0.1.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6012,16 +6024,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.1",
- "http-body-util",
  "mime",
  "pin-project-lite",
  "tower-layer",
@@ -6061,7 +6072,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6249,9 +6260,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "wasm-bindgen",
@@ -6322,7 +6333,7 @@ dependencies = [
  "ofb",
  "once_cell",
  "onig",
- "ordered-float 4.3.0",
+ "ordered-float 4.4.0",
  "paste",
  "peeking_take_while",
  "percent-encoding",
@@ -6419,9 +6430,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6430,24 +6441,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6457,9 +6468,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6467,28 +6478,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6816,7 +6827,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ ahash                  = "0.8"
 anyhow                 = "1"
 assert_matches         = "1.5.0"
 async-trait            = "0.1"
-aws-config             = "1.5.7"
+aws-config             = "1.5.8"
 aws-credential-types   = "1.2.1"
-aws-sdk-sqs            = "1.44.0"
+aws-sdk-sqs            = "1.46.0"
 aws-sigv4              = "1.2.4"
 aws-smithy-async       = "1.2.1"
 aws-smithy-http        = "0.60.11"
@@ -40,8 +40,8 @@ bd-test-helpers        = { git = "https://github.com/bitdriftlabs/shared-core.gi
 bd-time                = { git = "https://github.com/bitdriftlabs/shared-core.git" }
 built                  = { version = "0.7", features = ["git2"] }
 bytes                  = "1"
-cc                     = "1.1.24"
-clap                   = { version = "4.5.19", features = ["derive", "env"] }
+cc                     = "1.1.31"
+clap                   = { version = "4.5.20", features = ["derive", "env"] }
 comfy-table            = "7.1.1"
 console-subscriber     = "0.4.0"
 criterion              = { version = "0.5", features = ["html_reports"] }
@@ -52,13 +52,13 @@ deadpool               = { version = "0.12", features = ["managed", "rt_tokio_1"
 event-listener         = "5.3.1"
 fst                    = "0.4.7"
 futures                = "0.3"
-futures-util           = "0.3.30"
+futures-util           = "0.3.31"
 gettid                 = "0.1.3"
 hashbrown              = "0.15.0"
 http                   = "1.1.0"
 http-body-util         = "0.1.2"
 humantime-serde        = "1.1"
-hyper                  = "1.4.1"
+hyper                  = "1.5.0"
 
 hyper-rustls = { version = "0.27.3", default-features = false, features = [
   "http1",
@@ -73,7 +73,7 @@ intrusive-collections = "0.9.7"
 itertools             = "0.13.0"
 k8s-openapi           = { version = "0.23.0", features = ["v1_26"] }
 
-kube = { version = "0.95.0", features = [
+kube = { version = "0.96.0", features = [
   "runtime",
   "derive",
   "rustls-tls",
@@ -105,7 +105,7 @@ rand_xoshiro               = "0.6"
 regex                      = "1"
 reqwest                    = { version = "0.12.8", default-features = false, features = ["rustls-tls-webpki-roots"] }
 reusable-fmt               = "0.2.0"
-rustls                     = "0.23.13"
+rustls                     = "0.23.15"
 serde                      = { version = "1", features = ["derive"] }
 serde_json                 = "1"
 serde_yaml                 = "0.9.34"
@@ -125,7 +125,7 @@ topological-sort           = "0.2.2"
 tracing                    = "0.1.40"
 unwrap-infallible          = "0.1.5"
 url                        = "2.5.2"
-uuid                       = { version = "1.10.0", features = ["v4"] }
+uuid                       = { version = "1.11.0", features = ["v4"] }
 
 vrl = { git = "https://github.com/mattklein123/vrl.git", branch = "performance-20240826", default-features = false, features = [
   "compiler",

--- a/ci/check_license.sh
+++ b/ci/check_license.sh
@@ -6,6 +6,6 @@ python3 ./ci/license_header.py
 
 # Check if git repository is dirty
 if [[ -n $(git status --porcelain) ]]; then
-  echo "Error: Git repository is dirty. Run ci/license_headers.py to update license headers."
+  echo "Error: Git repository is dirty. Run ci/check_license.sh to update license headers."
   exit 1
 fi

--- a/pulse-metrics/src/clients/prom.rs
+++ b/pulse-metrics/src/clients/prom.rs
@@ -81,7 +81,7 @@ struct AwsAuthInner {
 
 enum Auth {
   Bearer(String),
-  Aws(AwsAuthInner),
+  Aws(Box<AwsAuthInner>),
 }
 
 /// A thin client wrapper used for mocking in tests
@@ -147,13 +147,13 @@ impl HyperPromRemoteWriteClient {
             .build()
             .unwrap();
 
-          Auth::Aws(AwsAuthInner {
+          Auth::Aws(Box::new(AwsAuthInner {
             sdk_config,
             identity_resolver: SharedIdentityResolver::new(credentials_provider),
             identity_cache,
             runtime_components,
             config_bag: ConfigBag::base(),
-          })
+          }))
         },
       },
     }))

--- a/pulse-metrics/src/lib.rs
+++ b/pulse-metrics/src/lib.rs
@@ -14,6 +14,7 @@ pub mod lru_map;
 pub mod metric_generator;
 pub mod pipeline;
 pub mod protos;
+pub mod reservoir_timer;
 pub mod test;
 pub mod vrl;
 

--- a/pulse-metrics/src/pipeline/inflow/wire/mod.rs
+++ b/pulse-metrics/src/pipeline/inflow/wire/mod.rs
@@ -5,6 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+mod pre_buffer;
 pub mod tcp;
 pub mod udp;
 pub mod unix;

--- a/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
+++ b/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
@@ -1,3 +1,10 @@
+// pulse - bitdrift's observability proxy
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use crate::protos::metric::{
   default_timestamp,
   CounterType,

--- a/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
+++ b/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
@@ -1,0 +1,140 @@
+use crate::protos::metric::{
+  default_timestamp,
+  CounterType,
+  DownstreamId,
+  Metric,
+  MetricId,
+  MetricSource,
+  MetricType,
+  MetricValue,
+  ParsedMetric,
+};
+use crate::reservoir_timer::ReservoirTimer;
+use ahash::AHashMap;
+use bd_log::warn_every;
+use std::collections::hash_map::Entry;
+use std::time::Instant;
+use time::ext::NumericalDuration;
+
+//
+// PreBufferMetric
+//
+
+enum PreBufferMetric {
+  Counter(f64),
+  Gauge(f64),
+  Timer(ReservoirTimer),
+}
+
+//
+// PreBuffer
+//
+
+// This is a simple aggregation system designed for pre-buffering statsd metrics when enabled via
+// the pre_buffer_window setting. See the documentation of that setting for more information.
+// This will only realistically work for statsd but could be expanded to other protocols in the
+// future if needed.
+#[derive(Default)]
+pub struct PreBuffer {
+  metrics: AHashMap<MetricId, PreBufferMetric>,
+}
+
+impl PreBuffer {
+  pub fn buffer(&mut self, metrics: Vec<ParsedMetric>) {
+    for metric in metrics {
+      let (metric_id, sample_rate, _, value) = metric.into_metric().into_parts();
+      let mtype = metric_id.mtype();
+      let metric = match self.metrics.entry(metric_id) {
+        Entry::Occupied(entry) => entry.into_mut(),
+        Entry::Vacant(entry) => {
+          let new_metric = match mtype {
+            Some(MetricType::Counter(CounterType::Delta)) => PreBufferMetric::Counter(0.0),
+            Some(MetricType::Gauge | MetricType::DeltaGauge | MetricType::DirectGauge) => {
+              PreBufferMetric::Gauge(0.0)
+            },
+            Some(MetricType::Timer) => PreBufferMetric::Timer(ReservoirTimer::new(100)),
+            _ => {
+              warn_every!(
+                15.seconds(),
+                "Unsupported pre-buffer metric type {:?} for metric {}",
+                mtype,
+                entry.key()
+              );
+              continue;
+            },
+          };
+          entry.insert(new_metric)
+        },
+      };
+
+      match (metric, mtype) {
+        (
+          PreBufferMetric::Counter(ref mut counter),
+          Some(MetricType::Counter(CounterType::Delta)),
+        ) => {
+          *counter += value.to_simple() * (1.0 / sample_rate.unwrap_or(1.0));
+        },
+        (
+          PreBufferMetric::Gauge(ref mut gauge),
+          Some(MetricType::Gauge | MetricType::DirectGauge),
+        ) => {
+          *gauge = value.to_simple();
+        },
+        (PreBufferMetric::Gauge(ref mut gauge), Some(MetricType::DeltaGauge)) => {
+          *gauge += value.to_simple();
+        },
+        (PreBufferMetric::Timer(timer), Some(MetricType::Timer)) => {
+          timer.aggregate(value.to_simple(), sample_rate.unwrap_or(1.0));
+        },
+        _ => {
+          warn_every!(15.seconds(), "Pre-buffer metric changed type {:?}", mtype);
+        },
+      }
+    }
+  }
+
+  pub fn flush(self, downstream_id: &DownstreamId) -> Vec<ParsedMetric> {
+    let now_instant = Instant::now();
+    let now_unix = default_timestamp();
+
+    let mut ret = Vec::new();
+    for (id, metric) in self.metrics {
+      match metric {
+        PreBufferMetric::Counter(counter) => {
+          ret.push(ParsedMetric::new(
+            Metric::new(id, None, now_unix, MetricValue::Simple(counter)),
+            MetricSource::Aggregation { prom_source: false },
+            now_instant,
+            downstream_id.clone(),
+          ));
+        },
+        PreBufferMetric::Gauge(gauge) => {
+          ret.push(ParsedMetric::new(
+            Metric::new(id, None, now_unix, MetricValue::Simple(gauge)),
+            MetricSource::Aggregation { prom_source: false },
+            now_instant,
+            downstream_id.clone(),
+          ));
+        },
+        PreBufferMetric::Timer(mut timer) => {
+          let (reservoir, count) = timer.drain();
+          let sample_rate = reservoir.len() as f64 / count;
+          for value in reservoir {
+            ret.push(ParsedMetric::new(
+              Metric::new(
+                id.clone(),
+                Some(sample_rate),
+                now_unix,
+                MetricValue::Simple(value),
+              ),
+              MetricSource::Aggregation { prom_source: false },
+              now_instant,
+              downstream_id.clone(),
+            ));
+          }
+        },
+      }
+    }
+    ret
+  }
+}

--- a/pulse-metrics/src/pipeline/processor/aggregation/reservoir_timer.rs
+++ b/pulse-metrics/src/pipeline/processor/aggregation/reservoir_timer.rs
@@ -7,54 +7,26 @@
 
 use super::make_metric;
 use crate::protos::metric::{MetricId, MetricType, MetricValue, ParsedMetric};
-use rand::{RngCore, SeedableRng};
-use rand_xoshiro::Xoshiro128StarStar;
-use std::cell::RefCell;
+use crate::reservoir_timer::ReservoirTimer;
 use tokio::time::Instant;
 
 //
 // ReservoirTimerAggregation
 //
 
-// This is a basic reservoir sampling implementation adapted from statsrelay. A reservoir is kept
-// with a maximum number of samples during each interval. Extra samples are randomly replaced with
-// a chance that decreases as the number of overall samples increases.
 pub(super) struct ReservoirTimerAggregation {
-  reservoir: Vec<f64>,
-  filled_count: u32,
-  reservoir_size: u32,
-  count: f64,
+  reservoir: ReservoirTimer,
 }
 
 impl ReservoirTimerAggregation {
   pub(super) fn new(reservoir_size: u32) -> Self {
     Self {
-      reservoir: Vec::with_capacity(reservoir_size as usize),
-      filled_count: 0,
-      reservoir_size,
-      count: 0.0,
+      reservoir: ReservoirTimer::new(reservoir_size),
     }
   }
 
   pub(super) fn aggregate(&mut self, value: f64, sample_rate: f64) {
-    thread_local! {
-      // Fast non crypto rng.
-      static RANDOM: RefCell<Xoshiro128StarStar> = RefCell::new(Xoshiro128StarStar::from_entropy());
-    }
-
-    // Do an initial fill if we haven't filled the full reservoir.
-    if self.reservoir.len() < self.reservoir_size as usize {
-      self.reservoir.push(value);
-    } else {
-      match RANDOM.with(|r| r.borrow_mut().next_u32()) % self.filled_count {
-        idx if idx < self.reservoir_size => self.reservoir[idx as usize] = value,
-        _ => (),
-      }
-    }
-    // Keep track of a sample rate scaled count independently from the
-    // reservoir sample fill
-    self.count += 1.0 / sample_rate;
-    self.filled_count += 1;
+    self.reservoir.aggregate(value, sample_rate);
   }
 
   pub(super) fn produce_metrics(
@@ -65,12 +37,10 @@ impl ReservoirTimerAggregation {
     prom_source: bool,
   ) -> Vec<Option<ParsedMetric>> {
     // Derive the sample rate based on the number of overall samples we got.
-    let sample_rate = self.reservoir.len() as f64 / self.count;
-    self.count = 0.0;
-    self.filled_count = 0;
-    self
-      .reservoir
-      .drain(..)
+    let (reservoir, count) = self.reservoir.drain();
+    let sample_rate = reservoir.len() as f64 / count;
+    reservoir
+      .into_iter()
       .map(|t| {
         make_metric(
           metric_id.name().clone(),

--- a/pulse-metrics/src/pipeline/processor/internode/mod.rs
+++ b/pulse-metrics/src/pipeline/processor/internode/mod.rs
@@ -217,7 +217,7 @@ impl InternodeProcessor {
           trace!("determined client {:?}", index);
           let (_, entry) = outbound_map
             .entry(index)
-            .or_insert((client.clone(), Vec::default()));
+            .or_insert_with(|| (client.clone(), Vec::default()));
           entry.push(parsed_metric);
         } else {
           trace!("determined self as shard");

--- a/pulse-metrics/src/protos/metric.rs
+++ b/pulse-metrics/src/protos/metric.rs
@@ -406,6 +406,10 @@ impl Metric {
     }
   }
 
+  pub fn into_parts(self) -> (MetricId, Option<f64>, u64, MetricValue) {
+    (self.id, self.sample_rate, self.timestamp, self.value)
+  }
+
   pub const fn get_id(&self) -> &MetricId {
     &self.id
   }

--- a/pulse-metrics/src/reservoir_timer.rs
+++ b/pulse-metrics/src/reservoir_timer.rs
@@ -1,0 +1,53 @@
+use rand::{RngCore, SeedableRng};
+use rand_xoshiro::Xoshiro128StarStar;
+use std::cell::RefCell;
+
+// This is a basic reservoir sampling implementation adapted from statsrelay. A reservoir is kept
+// with a maximum number of samples during each interval. Extra samples are randomly replaced with
+// a chance that decreases as the number of overall samples increases.
+pub struct ReservoirTimer {
+  reservoir: Vec<f64>,
+  filled_count: u32,
+  reservoir_size: u32,
+  count: f64,
+}
+
+impl ReservoirTimer {
+  #[must_use]
+  pub fn new(reservoir_size: u32) -> Self {
+    Self {
+      reservoir: Vec::with_capacity(reservoir_size as usize),
+      filled_count: 0,
+      reservoir_size,
+      count: 0.0,
+    }
+  }
+
+  pub fn aggregate(&mut self, value: f64, sample_rate: f64) {
+    thread_local! {
+      // Fast non crypto rng.
+      static RANDOM: RefCell<Xoshiro128StarStar> = RefCell::new(Xoshiro128StarStar::from_entropy());
+    }
+
+    // Do an initial fill if we haven't filled the full reservoir.
+    if self.reservoir.len() < self.reservoir_size as usize {
+      self.reservoir.push(value);
+    } else {
+      match RANDOM.with(|r| r.borrow_mut().next_u32()) % self.filled_count {
+        idx if idx < self.reservoir_size => self.reservoir[idx as usize] = value,
+        _ => (),
+      }
+    }
+    // Keep track of a sample rate scaled count independently from the
+    // reservoir sample fill
+    self.count += 1.0 / sample_rate;
+    self.filled_count += 1;
+  }
+
+  pub fn drain(&mut self) -> (Vec<f64>, f64) {
+    let old_values = std::mem::take(&mut self.reservoir);
+    let old_count = std::mem::take(&mut self.count);
+    self.filled_count = 0;
+    (old_values, old_count)
+  }
+}

--- a/pulse-metrics/src/reservoir_timer.rs
+++ b/pulse-metrics/src/reservoir_timer.rs
@@ -1,3 +1,10 @@
+// pulse - bitdrift's observability proxy
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use rand::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro128StarStar;
 use std::cell::RefCell;

--- a/pulse-protobuf/proto/pulse/config/inflow/v1/wire.proto
+++ b/pulse-protobuf/proto/pulse/config/inflow/v1/wire.proto
@@ -42,6 +42,15 @@ message TcpServerConfig {
   // metrics will be looked up by remote IP to match the origin pod and its metadata to the
   // metrics.
   bool bind_k8s_pod_metadata_by_remote_ip = 4;
+
+  // An optional amount of time that metrics will be buffered by the inflow before being further
+  // dispatched. Practically, this is useful when relying on Kubernetes informer metadata and there
+  // is no external mechanism to synchronize pods fully starting (e.g., an init container) such that
+  // there is a potential race condition between pods sending statsd metrics prior to the informer
+  // being aware of the pod's existence. Defaults to disabled. 5s is a reasonable setting in most
+  // environments where the above conditions apply. Note that counters, gauges, and timers will
+  // be aggregated to avoid unbounded memory growth of the application sends a lot of metrics.
+  google.protobuf.Duration pre_buffer_window = 5;
 }
 
 // Configuration for a UDP based inflow.

--- a/pulse-protobuf/src/protos/pulse/config/inflow/v1/wire.rs
+++ b/pulse-protobuf/src/protos/pulse/config/inflow/v1/wire.rs
@@ -203,6 +203,8 @@ pub struct TcpServerConfig {
     pub advanced: ::protobuf::MessageField<AdvancedSocketServerConfig>,
     // @@protoc_insertion_point(field:pulse.config.inflow.v1.TcpServerConfig.bind_k8s_pod_metadata_by_remote_ip)
     pub bind_k8s_pod_metadata_by_remote_ip: bool,
+    // @@protoc_insertion_point(field:pulse.config.inflow.v1.TcpServerConfig.pre_buffer_window)
+    pub pre_buffer_window: ::protobuf::MessageField<::protobuf::well_known_types::duration::Duration>,
     // special fields
     // @@protoc_insertion_point(special_field:pulse.config.inflow.v1.TcpServerConfig.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -220,7 +222,7 @@ impl TcpServerConfig {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(4);
+        let mut fields = ::std::vec::Vec::with_capacity(5);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "bind",
@@ -241,6 +243,11 @@ impl TcpServerConfig {
             "bind_k8s_pod_metadata_by_remote_ip",
             |m: &TcpServerConfig| { &m.bind_k8s_pod_metadata_by_remote_ip },
             |m: &mut TcpServerConfig| { &mut m.bind_k8s_pod_metadata_by_remote_ip },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ::protobuf::well_known_types::duration::Duration>(
+            "pre_buffer_window",
+            |m: &TcpServerConfig| { &m.pre_buffer_window },
+            |m: &mut TcpServerConfig| { &mut m.pre_buffer_window },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<TcpServerConfig>(
             "TcpServerConfig",
@@ -272,6 +279,9 @@ impl ::protobuf::Message for TcpServerConfig {
                 32 => {
                     self.bind_k8s_pod_metadata_by_remote_ip = is.read_bool()?;
                 },
+                42 => {
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.pre_buffer_window)?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -298,6 +308,10 @@ impl ::protobuf::Message for TcpServerConfig {
         if self.bind_k8s_pod_metadata_by_remote_ip != false {
             my_size += 1 + 1;
         }
+        if let Some(v) = self.pre_buffer_window.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -315,6 +329,9 @@ impl ::protobuf::Message for TcpServerConfig {
         }
         if self.bind_k8s_pod_metadata_by_remote_ip != false {
             os.write_bool(4, self.bind_k8s_pod_metadata_by_remote_ip)?;
+        }
+        if let Some(v) = self.pre_buffer_window.as_ref() {
+            ::protobuf::rt::write_message_field_with_cached_size(5, v, os)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -337,6 +354,7 @@ impl ::protobuf::Message for TcpServerConfig {
         self.protocol.clear();
         self.advanced.clear();
         self.bind_k8s_pod_metadata_by_remote_ip = false;
+        self.pre_buffer_window.clear();
         self.special_fields.clear();
     }
 
@@ -346,6 +364,7 @@ impl ::protobuf::Message for TcpServerConfig {
             protocol: ::protobuf::MessageField::none(),
             advanced: ::protobuf::MessageField::none(),
             bind_k8s_pod_metadata_by_remote_ip: false,
+            pre_buffer_window: ::protobuf::MessageField::none(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -697,22 +716,23 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x02\x20\x01(\x04H\0R\nbufferSize\x88\x01\x01\x12[\n\x17max_connecti\
     on_duration\x18\x03\x20\x01(\x0b2\x19.google.protobuf.DurationR\x15maxCo\
     nnectionDurationB\x08\xfaB\x05\xaa\x01\x02*\0B\x0e\n\x0c_buffer_size\"\
-    \x94\x02\n\x0fTcpServerConfig\x12\x1b\n\x04bind\x18\x01\x20\x01(\tR\x04b\
+    \xdb\x02\n\x0fTcpServerConfig\x12\x1b\n\x04bind\x18\x01\x20\x01(\tR\x04b\
     indB\x07\xfaB\x04r\x02\x10\x01\x12J\n\x08protocol\x18\x02\x20\x01(\x0b2$\
     .pulse.config.common.v1.WireProtocolR\x08protocolB\x08\xfaB\x05\x8a\x01\
     \x02\x10\x01\x12N\n\x08advanced\x18\x03\x20\x01(\x0b22.pulse.config.infl\
     ow.v1.AdvancedSocketServerConfigR\x08advanced\x12H\n\"bind_k8s_pod_metad\
-    ata_by_remote_ip\x18\x04\x20\x01(\x08R\x1cbindK8sPodMetadataByRemoteIp\"\
-    \xc4\x01\n\x0fUdpServerConfig\x12\x1b\n\x04bind\x18\x01\x20\x01(\tR\x04b\
-    indB\x07\xfaB\x04r\x02\x10\x01\x12J\n\x08protocol\x18\x02\x20\x01(\x0b2$\
-    .pulse.config.common.v1.WireProtocolR\x08protocolB\x08\xfaB\x05\x8a\x01\
-    \x02\x10\x01\x12H\n\"bind_k8s_pod_metadata_by_remote_ip\x18\x03\x20\x01(\
-    \x08R\x1cbindK8sPodMetadataByRemoteIp\"\xcb\x01\n\x10UnixServerConfig\
-    \x12\x1b\n\x04path\x18\x01\x20\x01(\tR\x04pathB\x07\xfaB\x04r\x02\x10\
-    \x01\x12J\n\x08protocol\x18\x02\x20\x01(\x0b2$.pulse.config.common.v1.Wi\
-    reProtocolR\x08protocolB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x12N\n\x08adva\
-    nced\x18\x03\x20\x01(\x0b22.pulse.config.inflow.v1.AdvancedSocketServerC\
-    onfigR\x08advancedb\x06proto3\
+    ata_by_remote_ip\x18\x04\x20\x01(\x08R\x1cbindK8sPodMetadataByRemoteIp\
+    \x12E\n\x11pre_buffer_window\x18\x05\x20\x01(\x0b2\x19.google.protobuf.D\
+    urationR\x0fpreBufferWindow\"\xc4\x01\n\x0fUdpServerConfig\x12\x1b\n\x04\
+    bind\x18\x01\x20\x01(\tR\x04bindB\x07\xfaB\x04r\x02\x10\x01\x12J\n\x08pr\
+    otocol\x18\x02\x20\x01(\x0b2$.pulse.config.common.v1.WireProtocolR\x08pr\
+    otocolB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x12H\n\"bind_k8s_pod_metadata_b\
+    y_remote_ip\x18\x03\x20\x01(\x08R\x1cbindK8sPodMetadataByRemoteIp\"\xcb\
+    \x01\n\x10UnixServerConfig\x12\x1b\n\x04path\x18\x01\x20\x01(\tR\x04path\
+    B\x07\xfaB\x04r\x02\x10\x01\x12J\n\x08protocol\x18\x02\x20\x01(\x0b2$.pu\
+    lse.config.common.v1.WireProtocolR\x08protocolB\x08\xfaB\x05\x8a\x01\x02\
+    \x10\x01\x12N\n\x08advanced\x18\x03\x20\x01(\x0b22.pulse.config.inflow.v\
+    1.AdvancedSocketServerConfigR\x08advancedb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/pulse-proxy/src/test/integration/statsd.rs
+++ b/pulse-proxy/src/test/integration/statsd.rs
@@ -257,3 +257,149 @@ async fn tcp_k8s_pod_metadata_missing_pod() {
 
   helper.shutdown().await;
 }
+
+fmt_reuse! {
+STATSD_TCP_K8S_METADATA_PREBUFFER_CONFIG = r#"
+        pipeline:
+          inflows:
+            tcp:
+              routes: ["processor:pod_mutate"]
+              tcp:
+                bind: "inflow:tcp"
+                protocol:
+                  statsd: {{}}
+                bind_k8s_pod_metadata_by_remote_ip: true
+                pre_buffer_window: 1s
+
+          processors:
+            pod_mutate:
+              routes: ["outflow:tcp"]
+              mutate:
+                vrl_program: |
+                  .tags.namespace = string!(%k8s.namespace)
+                  .tags.pod = string!(%k8s.pod.name)
+                  .tags.foo_label = string!(%k8s.pod.labels.foo)
+                  .tags.foo_annotation = string!(%k8s.pod.annotations.foo)
+
+          outflows:
+            tcp:
+              tcp:
+                common:
+                  send_to: "{}"
+                  protocol:
+                    carbon: {{}}
+        "#;
+}
+
+#[tokio::test]
+async fn tcp_k8s_prebuffer() {
+  let bind_resolver = HelperBindResolver::new(&["fake_upstream", "inflow:tcp"], &[]).await;
+  let mut upstream = FakeWireUpstream::new("fake_upstream", bind_resolver.clone()).await;
+  let mut pods_info = PodsInfo::default();
+  pods_info.insert(make_pod_info(
+    "default",
+    "pod_a",
+    &btreemap!("foo" => "bar"),
+    btreemap!("foo" => "baz"),
+    None,
+    HashMap::default(),
+    "127.0.0.1",
+  ));
+  let (_pods_tx, pods_rx) = watch::channel(pods_info);
+
+  let helper = Helper::new_with_k8s(
+    &fmt!(
+      STATSD_TCP_K8S_METADATA_PREBUFFER_CONFIG,
+      bind_resolver.local_tcp_addr("fake_upstream")
+    ),
+    bind_resolver.clone(),
+    Some(pods_rx),
+  )
+  .await;
+  let mut stream = TcpStream::connect(bind_resolver.local_tcp_addr("inflow:tcp"))
+    .await
+    .unwrap();
+  // Demonstrate aggregation.
+  stream
+    .write_all(b"foo:1|c\nbar:2|g\nbaz:3|ms\nfoo:1|c\nbar:3|g\nbaz:4|ms\n")
+    .await
+    .unwrap();
+
+  // Need to sort due to aggregation hash table.
+  let mut metrics = upstream.wait_for_metrics().await;
+  metrics.sort_by(|lhs, rhs| {
+    lhs
+      .metric()
+      .get_id()
+      .name()
+      .cmp(rhs.metric().get_id().name())
+  });
+  assert_eq!(
+    clean_timestamps(parse_carbon_metrics(&[
+      "bar 3 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "baz 3 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "baz 4 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "foo 2 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+    ])),
+    clean_timestamps(metrics)
+  );
+
+  helper.shutdown().await;
+}
+
+#[tokio::test]
+async fn tcp_k8s_prebuffer_early_shutdown() {
+  let bind_resolver = HelperBindResolver::new(&["fake_upstream", "inflow:tcp"], &[]).await;
+  let mut upstream = FakeWireUpstream::new("fake_upstream", bind_resolver.clone()).await;
+  let mut pods_info = PodsInfo::default();
+  pods_info.insert(make_pod_info(
+    "default",
+    "pod_a",
+    &btreemap!("foo" => "bar"),
+    btreemap!("foo" => "baz"),
+    None,
+    HashMap::default(),
+    "127.0.0.1",
+  ));
+  let (_pods_tx, pods_rx) = watch::channel(pods_info);
+
+  let helper = Helper::new_with_k8s(
+    &fmt!(
+      STATSD_TCP_K8S_METADATA_PREBUFFER_CONFIG,
+      bind_resolver.local_tcp_addr("fake_upstream")
+    ),
+    bind_resolver.clone(),
+    Some(pods_rx),
+  )
+  .await;
+  let mut stream = TcpStream::connect(bind_resolver.local_tcp_addr("inflow:tcp"))
+    .await
+    .unwrap();
+  // Demonstrate aggregation.
+  stream
+    .write_all(b"foo:1|c\nbar:2|g\nbaz:3|ms\nfoo:1|c\nbar:3|g\nbaz:4|ms\n")
+    .await
+    .unwrap();
+  drop(stream);
+
+  // Need to sort due to aggregation hash table.
+  let mut metrics = upstream.wait_for_metrics().await;
+  metrics.sort_by(|lhs, rhs| {
+    lhs
+      .metric()
+      .get_id()
+      .name()
+      .cmp(rhs.metric().get_id().name())
+  });
+  assert_eq!(
+    clean_timestamps(parse_carbon_metrics(&[
+      "bar 3 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "baz 3 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "baz 4 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+      "foo 2 foo_annotation=baz foo_label=bar namespace=default pod=pod_a\n",
+    ])),
+    clean_timestamps(metrics)
+  );
+
+  helper.shutdown().await;
+}


### PR DESCRIPTION
This commit adds the ability apply a pre-buffer duration where metrics will be buffered for up to some period of time, and then flushed through the rest of the pipeline. This is useful in cases where k8s informer lag may lead to no metadata being available for new pods that send metrics right away without any external synchronization. This is only useful for TCP as it keys off of new streams. Theoretically it could be made to work for UDP by keeping track of newly seen IPs but this is deferred for now. UDP IP tracking would also not help with on-host IP recycling cases whereas TCP streams account for that.

Fixes BIT-3985