### PR TITLE
introduce the bulk timer internal metric type and various cleanups

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "api"]
-	path = api
-	url = https://github.com/bitdriftlabs/api

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.13"
+version = "1.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
+checksum = "9f40e82e858e02445402906e454a73e244c7f501fcae198977585946c48e8697"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "1ea835662a0af02443aa1396d39be523bbf8f11ee6fad20329607c480bea48c3"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen",
  "cc",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
+checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.53.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6493ce2b27a2687b0d8a2453bf6ad2499012e9720c3367cb1206496ede475443"
+checksum = "ebfafe6700b71329b055d118c97ec00c6d569a5a56fd2a07d8b2e13d7ace32a5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.53.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
+checksum = "921a13ed6aabe2d1258f65ef7804946255c799224440774c30e1a2c65cdf983a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.54.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
+checksum = "196c952738b05dfc917d82a3e9b5ba850822a6d6a86d677afda2a156cc172ceb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.54.1"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d324ef69247c6f3c6823755f408a68877ffb1a9afaff6dd8b0057c760de60"
+checksum = "33ef5b73a927ed80b44096f8c20fb4abae65469af15198367e179ae267256e9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -821,7 +821,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "color-backtrace",
  "log",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "log",
  "protobuf 4.0.0-alpha.0",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "base64ct",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime-config"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "async-trait",
  "bd-server-stats",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "log",
  "tokio",
@@ -1182,12 +1182,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#706290ee3f94640c4acf7c513156ca376cf9e4c1"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#1d509c7028a8c9c810b22d669705c4d6b24ceffd"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb65153674e51d3a42c8f27b05b9508cea85edfaade8aa46bc8fc18cecdfef3"
+checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a396e17ad94059c650db3d253bb6e25927f1eb462eede7e7a153bb6e75dce0a7"
+checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -4543,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.78"
+version = "2.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923004c561dc4ed49d1e19cbf2af39780666b32d99941dafe8561f311daffd3d"
+checksum = "5e952b621948e561e7859e0ef812b0ecdef7d035f26f52244e2d98cc8eff8678"
 dependencies = [
  "psl-types",
 ]
@@ -5579,9 +5579,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
 dependencies = [
  "itoa",
  "memchr",
@@ -6593,9 +6593,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ ahash                  = "0.8"
 anyhow                 = "1"
 assert_matches         = "1.5.0"
 async-trait            = "0.1"
-aws-config             = "1.5.13"
+aws-config             = "1.5.14"
 aws-credential-types   = "1.2.1"
-aws-sdk-sqs            = "1.53.0"
-aws-sigv4              = "1.2.6"
+aws-sdk-sqs            = "1.54.0"
+aws-sigv4              = "1.2.7"
 aws-smithy-async       = "1.2.4"
 aws-smithy-http        = "0.60.12"
 aws-smithy-runtime-api = { version = "1.7.3", features = ["test-util"] }
@@ -40,7 +40,7 @@ bd-test-helpers        = { git = "https://github.com/bitdriftlabs/shared-core.gi
 bd-time                = { git = "https://github.com/bitdriftlabs/shared-core.git" }
 built                  = { version = "0.7", features = ["git2"] }
 bytes                  = "1"
-cc                     = "1.2.9"
+cc                     = "1.2.10"
 clap                   = { version = "4.5.26", features = ["derive", "env"] }
 comfy-table            = "7.1.3"
 console-subscriber     = "0.4.1"

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,6 @@
 version: v2
 modules:
-  - path: api/thirdparty/
+  - path: pulse-protobuf/thirdparty/
   - path: pulse-protobuf/proto/
 lint:
   use:
@@ -16,7 +16,7 @@ lint:
     - RPC_RESPONSE_STANDARD_NAME
     - SERVICE_SUFFIX
   ignore:
-    - api/thirdparty/
+    - pulse-protobuf/thirdparty/
   service_suffix: Service
   disallow_comment_ignores: true
 breaking:

--- a/ci/license_header.py
+++ b/ci/license_header.py
@@ -19,6 +19,7 @@ exclude_dirs = (
     './.git',
     './api/',
     './pulse-protobuf/src/',
+    './pulse-protobuf/thirdparty/',
     './target/',
 )
 

--- a/pulse-metrics/src/pipeline/metric_cache.rs
+++ b/pulse-metrics/src/pipeline/metric_cache.rs
@@ -200,9 +200,9 @@ impl MetricKey {
       Some(MetricType::DirectGauge) => 4,
       Some(MetricType::Gauge) => 5,
       Some(MetricType::Histogram) => 6,
-      Some(MetricType::Set) => 7,
-      Some(MetricType::Summary) => 8,
-      Some(MetricType::Timer) => 9,
+      Some(MetricType::Summary) => 7,
+      Some(MetricType::Timer) => 8,
+      Some(MetricType::BulkTimer) => 9,
     }
   }
 
@@ -215,9 +215,9 @@ impl MetricKey {
       4 => Some(MetricType::DirectGauge),
       5 => Some(MetricType::Gauge),
       6 => Some(MetricType::Histogram),
-      7 => Some(MetricType::Set),
-      8 => Some(MetricType::Summary),
-      9 => Some(MetricType::Timer),
+      7 => Some(MetricType::Summary),
+      8 => Some(MetricType::Timer),
+      9 => Some(MetricType::BulkTimer),
       _ => unreachable!(),
     }
   }
@@ -308,8 +308,8 @@ impl Hash for MetricKey {
   }
 }
 
-impl Equivalent<MetricId> for Arc<MetricKey> {
-  fn equivalent(&self, other: &MetricId) -> bool {
+impl PartialEq<MetricId> for MetricKey {
+  fn eq(&self, other: &MetricId) -> bool {
     let mut buf = &self.data[..];
     let name_len = buf.get_u16() as usize;
     let mut index = 2;
@@ -320,7 +320,7 @@ impl Equivalent<MetricId> for Arc<MetricKey> {
     index += name_len;
 
     // Get metric type and the number of tags and advance past those bytes.
-    let mtype = MetricKey::u8_to_metric_type(buf.get_u8());
+    let mtype = Self::u8_to_metric_type(buf.get_u8());
     let tags_len = buf.get_u16() as usize;
     index += 3;
 
@@ -346,6 +346,12 @@ impl Equivalent<MetricId> for Arc<MetricKey> {
     }
 
     name == other.name() && mtype == other.mtype()
+  }
+}
+
+impl Equivalent<MetricId> for Arc<MetricKey> {
+  fn equivalent(&self, other: &MetricId) -> bool {
+    *self.as_ref() == *other
   }
 }
 

--- a/pulse-metrics/src/pipeline/outflow/prom/remote_write.rs
+++ b/pulse-metrics/src/pipeline/outflow/prom/remote_write.rs
@@ -689,8 +689,9 @@ impl Batch<ParsedMetric> for PromBatch {
       Self::Complete { .. } => unreachable!(),
     };
 
+    let received_at = samples.iter().map(ParsedMetric::received_at).collect();
     let write_request = ParsedMetric::to_write_request(
-      &samples,
+      samples,
       &ToWriteRequestOptions {
         metadata: if metadata_only {
           MetadataType::Only
@@ -704,7 +705,7 @@ impl Batch<ParsedMetric> for PromBatch {
     let size = compressed_write_request.len();
     *self = Self::Complete {
       compressed_write_request: compressed_write_request.into(),
-      received_at: samples.iter().map(ParsedMetric::received_at).collect(),
+      received_at,
       extra_headers,
     };
     size

--- a/pulse-metrics/src/pipeline/processor/internode/convert.rs
+++ b/pulse-metrics/src/pipeline/processor/internode/convert.rs
@@ -30,6 +30,7 @@ use pulse_protobuf::protos::pulse::internode::v1::metric::histogram::Bucket;
 use pulse_protobuf::protos::pulse::internode::v1::metric::metric::Value_type;
 use pulse_protobuf::protos::pulse::internode::v1::metric::summary::Quantile;
 use pulse_protobuf::protos::pulse::internode::v1::metric::{
+  BulkTimer,
   DownstreamId as ProtoDownstreamId,
   Histogram,
   Metric as ProtoMetric,
@@ -68,9 +69,9 @@ impl From<MetricType> for ProtoMetricType {
       MetricType::DirectGauge => Self::METRIC_TYPE_DIRECT_GAUGE,
       MetricType::Gauge => Self::METRIC_TYPE_GAUGE,
       MetricType::Histogram => Self::METRIC_TYPE_HISTOGRAM,
-      MetricType::Set => Self::METRIC_TYPE_SET,
       MetricType::Summary => Self::METRIC_TYPE_SUMMARY,
       MetricType::Timer => Self::METRIC_TYPE_TIMER,
+      MetricType::BulkTimer => Self::METRIC_TYPE_BULK_TIMER,
     }
   }
 }
@@ -87,9 +88,9 @@ impl TryFrom<EnumOrUnknown<ProtoMetricType>> for MetricType {
       ProtoMetricType::METRIC_TYPE_DIRECT_GAUGE => Ok(Self::DirectGauge),
       ProtoMetricType::METRIC_TYPE_GAUGE => Ok(Self::Gauge),
       ProtoMetricType::METRIC_TYPE_HISTOGRAM => Ok(Self::Histogram),
-      ProtoMetricType::METRIC_TYPE_SET => Ok(Self::Set),
       ProtoMetricType::METRIC_TYPE_SUMMARY => Ok(Self::Summary),
       ProtoMetricType::METRIC_TYPE_TIMER => Ok(Self::Timer),
+      ProtoMetricType::METRIC_TYPE_BULK_TIMER => Ok(Self::BulkTimer),
     }
   }
 }
@@ -213,6 +214,10 @@ impl From<&ParsedMetric> for ProtoMetric {
           sample_sum: summary.sample_sum,
           ..Default::default()
         }),
+        MetricValue::BulkTimer(values) => Value_type::BulkTimer(BulkTimer {
+          values: values.clone(),
+          ..Default::default()
+        }),
       }),
       metric_source: Some(m.source().into()).into(),
       received_at: 0, // TODO(mattklein123): Support received_at.
@@ -294,6 +299,7 @@ pub fn proto_metric_to_parsed_metric(m: ProtoMetric) -> Result<ParsedMetric, Par
           sample_count: summary.sample_count,
           sample_sum: summary.sample_sum,
         }),
+        Value_type::BulkTimer(bulk_timer) => MetricValue::BulkTimer(bulk_timer.values),
       },
     ),
     source,

--- a/pulse-metrics/src/protos/carbon.rs
+++ b/pulse-metrics/src/protos/carbon.rs
@@ -139,7 +139,7 @@ fn write_carbon_tag(line: &mut bytes::BytesMut, tag: &TagValue) {
 }
 
 pub fn to_carbon_line(metric: &Metric) -> bytes::Bytes {
-  // TODO(mattklein123): Histograms/summaries are blocked at the wire outflow level.
+  // TODO(mattklein123): Histograms/summaries/bulk timers are blocked at the wire outflow level.
   let value = metric.value.to_simple();
 
   let mut line = bytes::BytesMut::new();

--- a/pulse-metrics/src/protos/prom_test.rs
+++ b/pulse-metrics/src/protos/prom_test.rs
@@ -125,7 +125,7 @@ fn summary_round_trip() {
   );
 
   let write_request = to_write_request(
-    &metrics
+    metrics
       .into_iter()
       .map(|metric| {
         ParsedMetric::new(
@@ -234,7 +234,7 @@ fn histogram_round_trip() {
   );
 
   let write_request = to_write_request(
-    &metrics
+    metrics
       .into_iter()
       .map(|metric| {
         ParsedMetric::new(

--- a/pulse-metrics/src/protos/statsd_test.rs
+++ b/pulse-metrics/src/protos/statsd_test.rs
@@ -155,7 +155,6 @@ fn metric_types() -> anyhow::Result<()> {
     ("car:bar:3|g".into(), MetricType::Gauge),
     ("car:bar:3|G".into(), MetricType::DirectGauge),
     ("hello.bar:4.0|ms|#tags".into(), MetricType::Timer),
-    ("hello.bar:4.0|s|@1.0|#tags".into(), MetricType::Set),
   ];
   for (buf, expected_metric_type) in type_checks {
     println!("{}", String::from_utf8(buf.to_vec())?);

--- a/pulse-promcli/src/main.rs
+++ b/pulse-promcli/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> anyhow::Result<()> {
   );
 
   let write_request = to_write_request(
-    &[metric],
+    vec![metric],
     &ToWriteRequestOptions {
       metadata: if options.no_emit_metadata {
         MetadataType::None

--- a/pulse-protobuf/build.rs
+++ b/pulse-protobuf/build.rs
@@ -33,7 +33,7 @@ fn generate_directory(root_path: &Path, partial_path: &Path) {
             .oneofs_non_exhaustive(false)
             .file_header(GENERATED_HEADER.to_string()),
         )
-        .includes(["proto/", "../api/thirdparty/", "../api/src/"])
+        .includes(["proto/", "thirdparty/"])
         .inputs([file.path()])
         .out_dir(Path::new("src/protos").join(partial_path))
         .capture_stderr()

--- a/pulse-protobuf/proto/pulse/config/common/v1/common.proto
+++ b/pulse-protobuf/proto/pulse/config/common/v1/common.proto
@@ -71,10 +71,26 @@ message EnvInlineOrFile {
 }
 
 // A file that is watched on the filesystem, typically within a K8s config map.
+//
+// Note that `dir` watches for *renames* in this directory only without recursion. This limits
+// watched changes and is required for Kubernetes `ConfigMap` deployments.
+//
+// A Kubernetes `ConfigMap` deployment might work as follows:
+// 1. Mount `ConfigMap` to `/config_map/foo`.
+// 2. Set `dir` to `/config_map/foo`.
+// 3. Set `file` to `/config_map/foo/foo.yaml`.
+//
+// Internally Kubernetes will create the following structure:
+// 1. `/config_map/foo/real_data/foo.yaml`.
+// 2. `/config_map/foo/..data` -> `/config_map/foo/real_data`.
+// 3. `/config_map/foo/foo.yaml` -> `/config_map/foo/..data/foo.yaml`.
+//
+// Further data swaps will only rename the `..data` symlink.
 message RuntimeConfig {
-  // Directory to watch for updates.
+  // Directory to watch for updates. See above. This needs to be the directory that owns whatever
+  // symlink is being atomically swapped.
   string dir = 1 [(validate.rules).string = {min_len: 1}];
 
-  // File to watch for updates.
+  // File to watch for updates. This is the actual full file path.
   string file = 2 [(validate.rules).string = {min_len: 1}];
 }

--- a/pulse-protobuf/proto/pulse/config/processor/v1/aggregation.proto
+++ b/pulse-protobuf/proto/pulse/config/processor/v1/aggregation.proto
@@ -45,6 +45,16 @@ message AggregationConfig {
   message ReservoirTimers {
     // The size of the reservoir for each timer. If not set defaults to 100.
     optional uint32 reservoir_size = 1;
+
+    // If set to true, timers in the reservoir will be emitted as the synthetic "bulk timer" metric
+    // type. This type is internal to Pulse, but effectively packs all of the timer samples into
+    // a single pseudo metric to avoid repeated processing of metric names, tags, etc. If
+    // sending to another pulse layer that understands this format, this can yield substantial
+    // efficiency gains. Note if this type makes its way to a wire outflow, it will be converted
+    // back to individual timers. If it makes its way to prom remote write, the type will be
+    // emitted im bulk format, but only pulse understands how to read this format. Do not send
+    // this to other TSDBs.
+    bool emit_as_bulk_timer = 2;
   }
 
   message Counters {

--- a/pulse-protobuf/proto/pulse/internode/v1/metric.proto
+++ b/pulse-protobuf/proto/pulse/internode/v1/metric.proto
@@ -40,6 +40,10 @@ message DownstreamId {
   }
 }
 
+message BulkTimer {
+  repeated double values = 1;
+}
+
 message Metric {
   MetricId id = 1;
   optional double sample_rate = 2;
@@ -48,6 +52,7 @@ message Metric {
     double simple_value = 4;
     Histogram histogram = 5;
     Summary summary = 6;
+    BulkTimer bulk_timer = 10;
   }
   MetricSource metric_source = 7;
   uint64 received_at = 8;
@@ -84,8 +89,9 @@ enum MetricType {
   METRIC_TYPE_DELTA_GAUGE = 3;
   METRIC_TYPE_DIRECT_GAUGE = 4;
   METRIC_TYPE_GAUGE = 5;
-  METRIC_TYPE_SET = 6;
+  reserved 6;
   METRIC_TYPE_TIMER = 7;
   METRIC_TYPE_HISTOGRAM = 8;
   METRIC_TYPE_SUMMARY = 9;
+  METRIC_TYPE_BULK_TIMER = 10;
 }

--- a/pulse-protobuf/src/protos/pulse/config/processor/v1/aggregation.rs
+++ b/pulse-protobuf/src/protos/pulse/config/processor/v1/aggregation.rs
@@ -856,6 +856,8 @@ pub mod aggregation_config {
         // message fields
         // @@protoc_insertion_point(field:pulse.config.processor.v1.AggregationConfig.ReservoirTimers.reservoir_size)
         pub reservoir_size: ::std::option::Option<u32>,
+        // @@protoc_insertion_point(field:pulse.config.processor.v1.AggregationConfig.ReservoirTimers.emit_as_bulk_timer)
+        pub emit_as_bulk_timer: bool,
         // special fields
         // @@protoc_insertion_point(special_field:pulse.config.processor.v1.AggregationConfig.ReservoirTimers.special_fields)
         pub special_fields: ::protobuf::SpecialFields,
@@ -873,12 +875,17 @@ pub mod aggregation_config {
         }
 
         pub(in super) fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-            let mut fields = ::std::vec::Vec::with_capacity(1);
+            let mut fields = ::std::vec::Vec::with_capacity(2);
             let mut oneofs = ::std::vec::Vec::with_capacity(0);
             fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
                 "reservoir_size",
                 |m: &ReservoirTimers| { &m.reservoir_size },
                 |m: &mut ReservoirTimers| { &mut m.reservoir_size },
+            ));
+            fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+                "emit_as_bulk_timer",
+                |m: &ReservoirTimers| { &m.emit_as_bulk_timer },
+                |m: &mut ReservoirTimers| { &mut m.emit_as_bulk_timer },
             ));
             ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<ReservoirTimers>(
                 "AggregationConfig.ReservoirTimers",
@@ -901,6 +908,9 @@ pub mod aggregation_config {
                     8 => {
                         self.reservoir_size = ::std::option::Option::Some(is.read_uint32()?);
                     },
+                    16 => {
+                        self.emit_as_bulk_timer = is.read_bool()?;
+                    },
                     tag => {
                         ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                     },
@@ -916,6 +926,9 @@ pub mod aggregation_config {
             if let Some(v) = self.reservoir_size {
                 my_size += ::protobuf::rt::uint32_size(1, v);
             }
+            if self.emit_as_bulk_timer != false {
+                my_size += 1 + 1;
+            }
             my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
             self.special_fields.cached_size().set(my_size as u32);
             my_size
@@ -924,6 +937,9 @@ pub mod aggregation_config {
         fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
             if let Some(v) = self.reservoir_size {
                 os.write_uint32(1, v)?;
+            }
+            if self.emit_as_bulk_timer != false {
+                os.write_bool(2, self.emit_as_bulk_timer)?;
             }
             os.write_unknown_fields(self.special_fields.unknown_fields())?;
             ::std::result::Result::Ok(())
@@ -943,12 +959,14 @@ pub mod aggregation_config {
 
         fn clear(&mut self) {
             self.reservoir_size = ::std::option::Option::None;
+            self.emit_as_bulk_timer = false;
             self.special_fields.clear();
         }
 
         fn default_instance() -> &'static ReservoirTimers {
             static instance: ReservoirTimers = ReservoirTimers {
                 reservoir_size: ::std::option::Option::None,
+                emit_as_bulk_timer: false,
                 special_fields: ::protobuf::SpecialFields::new(),
             };
             &instance
@@ -2019,7 +2037,7 @@ pub mod aggregation_config {
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n+pulse/config/processor/v1/aggregation.proto\x12\x19pulse.config.proce\
     ssor.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wra\
-    ppers.proto\x1a\x17validate/validate.proto\"\x97\x11\n\x11AggregationCon\
+    ppers.proto\x1a\x17validate/validate.proto\"\xc4\x11\n\x11AggregationCon\
     fig\x12f\n\x0fquantile_timers\x18\x01\x20\x01(\x0b2;.pulse.config.proces\
     sor.v1.AggregationConfig.QuantileTimersH\0R\x0equantileTimers\x12i\n\x10\
     reservoir_timers\x18\x02\x20\x01(\x0b2<.pulse.config.processor.v1.Aggreg\
@@ -2046,15 +2064,16 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x01\x20\x01(\x08R\x04mean\x12\x14\n\x05lower\x18\x02\x20\x01(\x08R\
     \x05lower\x12\x14\n\x05upper\x18\x03\x20\x01(\x08R\x05upper\x12\x14\n\
     \x05count\x18\x04\x20\x01(\x08R\x05count\x12\x12\n\x04rate\x18\x05\x20\
-    \x01(\x08R\x04rateB\t\n\x07_prefixB\x06\n\x04_eps\x1aP\n\x0fReservoirTim\
+    \x01(\x08R\x04rateB\t\n\x07_prefixB\x06\n\x04_eps\x1a}\n\x0fReservoirTim\
     ers\x12*\n\x0ereservoir_size\x18\x01\x20\x01(\rH\0R\rreservoirSize\x88\
-    \x01\x01B\x11\n\x0f_reservoir_size\x1a\xc1\x03\n\x08Counters\x12\x1b\n\
-    \x06prefix\x18\x01\x20\x01(\tH\0R\x06prefix\x88\x01\x01\x12Z\n\x08extend\
-    ed\x18\x02\x20\x01(\x0b2>.pulse.config.processor.v1.AggregationConfig.Co\
-    unters.ExtendedR\x08extended\x12s\n\x11absolute_counters\x18\x03\x20\x01\
-    (\x0b2F.pulse.config.processor.v1.AggregationConfig.Counters.AbsoluteCou\
-    ntersR\x10absoluteCounters\x1aH\n\x10AbsoluteCounters\x124\n\x12emit_as_\
-    delta_rate\x18\x03\x20\x01(\x08R\x0femitAsDeltaRateB\x07\xfaB\x04j\x02\
+    \x01\x01\x12+\n\x12emit_as_bulk_timer\x18\x02\x20\x01(\x08R\x0femitAsBul\
+    kTimerB\x11\n\x0f_reservoir_size\x1a\xc1\x03\n\x08Counters\x12\x1b\n\x06\
+    prefix\x18\x01\x20\x01(\tH\0R\x06prefix\x88\x01\x01\x12Z\n\x08extended\
+    \x18\x02\x20\x01(\x0b2>.pulse.config.processor.v1.AggregationConfig.Coun\
+    ters.ExtendedR\x08extended\x12s\n\x11absolute_counters\x18\x03\x20\x01(\
+    \x0b2F.pulse.config.processor.v1.AggregationConfig.Counters.AbsoluteCoun\
+    tersR\x10absoluteCounters\x1aH\n\x10AbsoluteCounters\x124\n\x12emit_as_d\
+    elta_rate\x18\x03\x20\x01(\x08R\x0femitAsDeltaRateB\x07\xfaB\x04j\x02\
     \x08\x01\x1ar\n\x08Extended\x12\x14\n\x05count\x18\x01\x20\x01(\x08R\x05\
     count\x12\x10\n\x03sum\x18\x02\x20\x01(\x08R\x03sum\x12\x12\n\x04rate\
     \x18\x03\x20\x01(\x08R\x04rate\x12\x14\n\x05lower\x18\x04\x20\x01(\x08R\

--- a/pulse-protobuf/src/protos/pulse/internode/v1/metric.rs
+++ b/pulse-protobuf/src/protos/pulse/internode/v1/metric.rs
@@ -1062,6 +1062,127 @@ pub mod downstream_id {
     }
 }
 
+// @@protoc_insertion_point(message:pulse.internode.v1.BulkTimer)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct BulkTimer {
+    // message fields
+    // @@protoc_insertion_point(field:pulse.internode.v1.BulkTimer.values)
+    pub values: ::std::vec::Vec<f64>,
+    // special fields
+    // @@protoc_insertion_point(special_field:pulse.internode.v1.BulkTimer.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a BulkTimer {
+    fn default() -> &'a BulkTimer {
+        <BulkTimer as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl BulkTimer {
+    pub fn new() -> BulkTimer {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
+            "values",
+            |m: &BulkTimer| { &m.values },
+            |m: &mut BulkTimer| { &mut m.values },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<BulkTimer>(
+            "BulkTimer",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for BulkTimer {
+    const NAME: &'static str = "BulkTimer";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    is.read_repeated_packed_double_into(&mut self.values)?;
+                },
+                9 => {
+                    self.values.push(is.read_double()?);
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        my_size += ::protobuf::rt::vec_packed_double_size(1, &self.values);
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        os.write_repeated_packed_double(1, &self.values)?;
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> BulkTimer {
+        BulkTimer::new()
+    }
+
+    fn clear(&mut self) {
+        self.values.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static BulkTimer {
+        static instance: BulkTimer = BulkTimer {
+            values: ::std::vec::Vec::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for BulkTimer {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("BulkTimer").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for BulkTimer {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for BulkTimer {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 // @@protoc_insertion_point(message:pulse.internode.v1.Metric)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct Metric {
@@ -1219,8 +1340,57 @@ impl Metric {
         }
     }
 
+    // .pulse.internode.v1.BulkTimer bulk_timer = 10;
+
+    pub fn bulk_timer(&self) -> &BulkTimer {
+        match self.value_type {
+            ::std::option::Option::Some(metric::Value_type::BulkTimer(ref v)) => v,
+            _ => <BulkTimer as ::protobuf::Message>::default_instance(),
+        }
+    }
+
+    pub fn clear_bulk_timer(&mut self) {
+        self.value_type = ::std::option::Option::None;
+    }
+
+    pub fn has_bulk_timer(&self) -> bool {
+        match self.value_type {
+            ::std::option::Option::Some(metric::Value_type::BulkTimer(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_bulk_timer(&mut self, v: BulkTimer) {
+        self.value_type = ::std::option::Option::Some(metric::Value_type::BulkTimer(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_bulk_timer(&mut self) -> &mut BulkTimer {
+        if let ::std::option::Option::Some(metric::Value_type::BulkTimer(_)) = self.value_type {
+        } else {
+            self.value_type = ::std::option::Option::Some(metric::Value_type::BulkTimer(BulkTimer::new()));
+        }
+        match self.value_type {
+            ::std::option::Option::Some(metric::Value_type::BulkTimer(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_bulk_timer(&mut self) -> BulkTimer {
+        if self.has_bulk_timer() {
+            match self.value_type.take() {
+                ::std::option::Option::Some(metric::Value_type::BulkTimer(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            BulkTimer::new()
+        }
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(9);
+        let mut fields = ::std::vec::Vec::with_capacity(10);
         let mut oneofs = ::std::vec::Vec::with_capacity(1);
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MetricId>(
             "id",
@@ -1256,6 +1426,13 @@ impl Metric {
             Metric::summary,
             Metric::mut_summary,
             Metric::set_summary,
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, BulkTimer>(
+            "bulk_timer",
+            Metric::has_bulk_timer,
+            Metric::bulk_timer,
+            Metric::mut_bulk_timer,
+            Metric::set_bulk_timer,
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MetricSource>(
             "metric_source",
@@ -1308,6 +1485,9 @@ impl ::protobuf::Message for Metric {
                 },
                 50 => {
                     self.value_type = ::std::option::Option::Some(metric::Value_type::Summary(is.read_message()?));
+                },
+                82 => {
+                    self.value_type = ::std::option::Option::Some(metric::Value_type::BulkTimer(is.read_message()?));
                 },
                 58 => {
                     ::protobuf::rt::read_singular_message_into_field(is, &mut self.metric_source)?;
@@ -1364,6 +1544,10 @@ impl ::protobuf::Message for Metric {
                     let len = v.compute_size();
                     my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
                 },
+                &metric::Value_type::BulkTimer(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+                },
             };
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
@@ -1401,6 +1585,9 @@ impl ::protobuf::Message for Metric {
                 &metric::Value_type::Summary(ref v) => {
                     ::protobuf::rt::write_message_field_with_cached_size(6, v, os)?;
                 },
+                &metric::Value_type::BulkTimer(ref v) => {
+                    ::protobuf::rt::write_message_field_with_cached_size(10, v, os)?;
+                },
             };
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
@@ -1423,6 +1610,7 @@ impl ::protobuf::Message for Metric {
         self.id.clear();
         self.sample_rate = ::std::option::Option::None;
         self.timestamp = 0;
+        self.value_type = ::std::option::Option::None;
         self.value_type = ::std::option::Option::None;
         self.value_type = ::std::option::Option::None;
         self.value_type = ::std::option::Option::None;
@@ -1476,6 +1664,8 @@ pub mod metric {
         Histogram(super::Histogram),
         // @@protoc_insertion_point(oneof_field:pulse.internode.v1.Metric.summary)
         Summary(super::Summary),
+        // @@protoc_insertion_point(oneof_field:pulse.internode.v1.Metric.bulk_timer)
+        BulkTimer(super::BulkTimer),
     }
 
     impl ::protobuf::Oneof for Value_type {
@@ -2021,14 +2211,14 @@ pub enum MetricType {
     METRIC_TYPE_DIRECT_GAUGE = 4,
     // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_GAUGE)
     METRIC_TYPE_GAUGE = 5,
-    // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_SET)
-    METRIC_TYPE_SET = 6,
     // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_TIMER)
     METRIC_TYPE_TIMER = 7,
     // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_HISTOGRAM)
     METRIC_TYPE_HISTOGRAM = 8,
     // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_SUMMARY)
     METRIC_TYPE_SUMMARY = 9,
+    // @@protoc_insertion_point(enum_value:pulse.internode.v1.MetricType.METRIC_TYPE_BULK_TIMER)
+    METRIC_TYPE_BULK_TIMER = 10,
 }
 
 impl ::protobuf::Enum for MetricType {
@@ -2046,10 +2236,10 @@ impl ::protobuf::Enum for MetricType {
             3 => ::std::option::Option::Some(MetricType::METRIC_TYPE_DELTA_GAUGE),
             4 => ::std::option::Option::Some(MetricType::METRIC_TYPE_DIRECT_GAUGE),
             5 => ::std::option::Option::Some(MetricType::METRIC_TYPE_GAUGE),
-            6 => ::std::option::Option::Some(MetricType::METRIC_TYPE_SET),
             7 => ::std::option::Option::Some(MetricType::METRIC_TYPE_TIMER),
             8 => ::std::option::Option::Some(MetricType::METRIC_TYPE_HISTOGRAM),
             9 => ::std::option::Option::Some(MetricType::METRIC_TYPE_SUMMARY),
+            10 => ::std::option::Option::Some(MetricType::METRIC_TYPE_BULK_TIMER),
             _ => ::std::option::Option::None
         }
     }
@@ -2062,10 +2252,10 @@ impl ::protobuf::Enum for MetricType {
             "METRIC_TYPE_DELTA_GAUGE" => ::std::option::Option::Some(MetricType::METRIC_TYPE_DELTA_GAUGE),
             "METRIC_TYPE_DIRECT_GAUGE" => ::std::option::Option::Some(MetricType::METRIC_TYPE_DIRECT_GAUGE),
             "METRIC_TYPE_GAUGE" => ::std::option::Option::Some(MetricType::METRIC_TYPE_GAUGE),
-            "METRIC_TYPE_SET" => ::std::option::Option::Some(MetricType::METRIC_TYPE_SET),
             "METRIC_TYPE_TIMER" => ::std::option::Option::Some(MetricType::METRIC_TYPE_TIMER),
             "METRIC_TYPE_HISTOGRAM" => ::std::option::Option::Some(MetricType::METRIC_TYPE_HISTOGRAM),
             "METRIC_TYPE_SUMMARY" => ::std::option::Option::Some(MetricType::METRIC_TYPE_SUMMARY),
+            "METRIC_TYPE_BULK_TIMER" => ::std::option::Option::Some(MetricType::METRIC_TYPE_BULK_TIMER),
             _ => ::std::option::Option::None
         }
     }
@@ -2077,10 +2267,10 @@ impl ::protobuf::Enum for MetricType {
         MetricType::METRIC_TYPE_DELTA_GAUGE,
         MetricType::METRIC_TYPE_DIRECT_GAUGE,
         MetricType::METRIC_TYPE_GAUGE,
-        MetricType::METRIC_TYPE_SET,
         MetricType::METRIC_TYPE_TIMER,
         MetricType::METRIC_TYPE_HISTOGRAM,
         MetricType::METRIC_TYPE_SUMMARY,
+        MetricType::METRIC_TYPE_BULK_TIMER,
     ];
 }
 
@@ -2091,7 +2281,18 @@ impl ::protobuf::EnumFull for MetricType {
     }
 
     fn descriptor(&self) -> ::protobuf::reflect::EnumValueDescriptor {
-        let index = *self as usize;
+        let index = match self {
+            MetricType::METRIC_TYPE_UNSPECIFIED => 0,
+            MetricType::METRIC_TYPE_DELTA_COUNTER => 1,
+            MetricType::METRIC_TYPE_ABSOLUTE_COUNTER => 2,
+            MetricType::METRIC_TYPE_DELTA_GAUGE => 3,
+            MetricType::METRIC_TYPE_DIRECT_GAUGE => 4,
+            MetricType::METRIC_TYPE_GAUGE => 5,
+            MetricType::METRIC_TYPE_TIMER => 6,
+            MetricType::METRIC_TYPE_HISTOGRAM => 7,
+            MetricType::METRIC_TYPE_SUMMARY => 8,
+            MetricType::METRIC_TYPE_BULK_TIMER => 9,
+        };
         Self::enum_descriptor().value_by_index(index)
     }
 }
@@ -2124,36 +2325,38 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12unix_domain_socket\x18\x02\x20\x01(\tH\0R\x10unixDomainSocket\x12#\n\
     \x0cipv4_address\x18\x03\x20\x01(\rH\0R\x0bipv4Address\x12#\n\x0cipv6_ad\
     dress\x18\x04\x20\x01(\x0cH\0R\x0bipv6Address\x12)\n\x0finflow_provided\
-    \x18\x05\x20\x01(\x0cH\0R\x0einflowProvidedB\t\n\x07id_type\"\xe4\x03\n\
-    \x06Metric\x12,\n\x02id\x18\x01\x20\x01(\x0b2\x1c.pulse.internode.v1.Met\
-    ricIdR\x02id\x12$\n\x0bsample_rate\x18\x02\x20\x01(\x01H\x01R\nsampleRat\
-    e\x88\x01\x01\x12\x1c\n\ttimestamp\x18\x03\x20\x01(\x04R\ttimestamp\x12#\
-    \n\x0csimple_value\x18\x04\x20\x01(\x01H\0R\x0bsimpleValue\x12=\n\thisto\
-    gram\x18\x05\x20\x01(\x0b2\x1d.pulse.internode.v1.HistogramH\0R\thistogr\
-    am\x127\n\x07summary\x18\x06\x20\x01(\x0b2\x1b.pulse.internode.v1.Summar\
-    yH\0R\x07summary\x12E\n\rmetric_source\x18\x07\x20\x01(\x0b2\x20.pulse.i\
-    nternode.v1.MetricSourceR\x0cmetricSource\x12\x1f\n\x0breceived_at\x18\
-    \x08\x20\x01(\x04R\nreceivedAt\x12E\n\rdownstream_id\x18\t\x20\x01(\x0b2\
-    \x20.pulse.internode.v1.DownstreamIdR\x0cdownstreamIdB\x0c\n\nvalue_type\
-    B\x0e\n\x0c_sample_rate\"\x83\x01\n\x0cMetricSource\x12E\n\rwire_protoco\
-    l\x18\x01\x20\x01(\x0e2\x20.pulse.internode.v1.WireProtocolR\x0cwireProt\
-    ocol\x12\x1f\n\x08original\x18\x02\x20\x01(\x0cH\0R\x08original\x88\x01\
-    \x01B\x0b\n\t_original\"2\n\x08TagValue\x12\x10\n\x03tag\x18\x01\x20\x01\
-    (\x0cR\x03tag\x12\x14\n\x05value\x18\x02\x20\x01(\x0cR\x05value\"\xb1\
-    \x01\n\x08MetricId\x12\x12\n\x04name\x18\x01\x20\x01(\x0cR\x04name\x12D\
-    \n\x0bmetric_type\x18\x02\x20\x01(\x0e2\x1e.pulse.internode.v1.MetricTyp\
-    eH\0R\nmetricType\x88\x01\x01\x12;\n\ntag_values\x18\x03\x20\x03(\x0b2\
-    \x1c.pulse.internode.v1.TagValueR\ttagValuesB\x0e\n\x0c_metric_type*y\n\
-    \x0cWireProtocol\x12\x1d\n\x19WIRE_PROTOCOL_UNSPECIFIED\x10\0\x12\x18\n\
-    \x14WIRE_PROTOCOL_CARBON\x10\x01\x12\x18\n\x14WIRE_PROTOCOL_STATSD\x10\
-    \x02\x12\x16\n\x12WIRE_PROTOCOL_PROM\x10\x03*\x9c\x02\n\nMetricType\x12\
-    \x1b\n\x17METRIC_TYPE_UNSPECIFIED\x10\0\x12\x1d\n\x19METRIC_TYPE_DELTA_C\
-    OUNTER\x10\x01\x12\x20\n\x1cMETRIC_TYPE_ABSOLUTE_COUNTER\x10\x02\x12\x1b\
-    \n\x17METRIC_TYPE_DELTA_GAUGE\x10\x03\x12\x1c\n\x18METRIC_TYPE_DIRECT_GA\
-    UGE\x10\x04\x12\x15\n\x11METRIC_TYPE_GAUGE\x10\x05\x12\x13\n\x0fMETRIC_T\
-    YPE_SET\x10\x06\x12\x15\n\x11METRIC_TYPE_TIMER\x10\x07\x12\x19\n\x15METR\
-    IC_TYPE_HISTOGRAM\x10\x08\x12\x17\n\x13METRIC_TYPE_SUMMARY\x10\tb\x06pro\
-    to3\
+    \x18\x05\x20\x01(\x0cH\0R\x0einflowProvidedB\t\n\x07id_type\"#\n\tBulkTi\
+    mer\x12\x16\n\x06values\x18\x01\x20\x03(\x01R\x06values\"\xa4\x04\n\x06M\
+    etric\x12,\n\x02id\x18\x01\x20\x01(\x0b2\x1c.pulse.internode.v1.MetricId\
+    R\x02id\x12$\n\x0bsample_rate\x18\x02\x20\x01(\x01H\x01R\nsampleRate\x88\
+    \x01\x01\x12\x1c\n\ttimestamp\x18\x03\x20\x01(\x04R\ttimestamp\x12#\n\
+    \x0csimple_value\x18\x04\x20\x01(\x01H\0R\x0bsimpleValue\x12=\n\thistogr\
+    am\x18\x05\x20\x01(\x0b2\x1d.pulse.internode.v1.HistogramH\0R\thistogram\
+    \x127\n\x07summary\x18\x06\x20\x01(\x0b2\x1b.pulse.internode.v1.SummaryH\
+    \0R\x07summary\x12>\n\nbulk_timer\x18\n\x20\x01(\x0b2\x1d.pulse.internod\
+    e.v1.BulkTimerH\0R\tbulkTimer\x12E\n\rmetric_source\x18\x07\x20\x01(\x0b\
+    2\x20.pulse.internode.v1.MetricSourceR\x0cmetricSource\x12\x1f\n\x0brece\
+    ived_at\x18\x08\x20\x01(\x04R\nreceivedAt\x12E\n\rdownstream_id\x18\t\
+    \x20\x01(\x0b2\x20.pulse.internode.v1.DownstreamIdR\x0cdownstreamIdB\x0c\
+    \n\nvalue_typeB\x0e\n\x0c_sample_rate\"\x83\x01\n\x0cMetricSource\x12E\n\
+    \rwire_protocol\x18\x01\x20\x01(\x0e2\x20.pulse.internode.v1.WireProtoco\
+    lR\x0cwireProtocol\x12\x1f\n\x08original\x18\x02\x20\x01(\x0cH\0R\x08ori\
+    ginal\x88\x01\x01B\x0b\n\t_original\"2\n\x08TagValue\x12\x10\n\x03tag\
+    \x18\x01\x20\x01(\x0cR\x03tag\x12\x14\n\x05value\x18\x02\x20\x01(\x0cR\
+    \x05value\"\xb1\x01\n\x08MetricId\x12\x12\n\x04name\x18\x01\x20\x01(\x0c\
+    R\x04name\x12D\n\x0bmetric_type\x18\x02\x20\x01(\x0e2\x1e.pulse.internod\
+    e.v1.MetricTypeH\0R\nmetricType\x88\x01\x01\x12;\n\ntag_values\x18\x03\
+    \x20\x03(\x0b2\x1c.pulse.internode.v1.TagValueR\ttagValuesB\x0e\n\x0c_me\
+    tric_type*y\n\x0cWireProtocol\x12\x1d\n\x19WIRE_PROTOCOL_UNSPECIFIED\x10\
+    \0\x12\x18\n\x14WIRE_PROTOCOL_CARBON\x10\x01\x12\x18\n\x14WIRE_PROTOCOL_\
+    STATSD\x10\x02\x12\x16\n\x12WIRE_PROTOCOL_PROM\x10\x03*\xa9\x02\n\nMetri\
+    cType\x12\x1b\n\x17METRIC_TYPE_UNSPECIFIED\x10\0\x12\x1d\n\x19METRIC_TYP\
+    E_DELTA_COUNTER\x10\x01\x12\x20\n\x1cMETRIC_TYPE_ABSOLUTE_COUNTER\x10\
+    \x02\x12\x1b\n\x17METRIC_TYPE_DELTA_GAUGE\x10\x03\x12\x1c\n\x18METRIC_TY\
+    PE_DIRECT_GAUGE\x10\x04\x12\x15\n\x11METRIC_TYPE_GAUGE\x10\x05\x12\x15\n\
+    \x11METRIC_TYPE_TIMER\x10\x07\x12\x19\n\x15METRIC_TYPE_HISTOGRAM\x10\x08\
+    \x12\x17\n\x13METRIC_TYPE_SUMMARY\x10\t\x12\x1a\n\x16METRIC_TYPE_BULK_TI\
+    MER\x10\n\"\x04\x08\x06\x10\x06b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -2171,10 +2374,11 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(9);
+            let mut messages = ::std::vec::Vec::with_capacity(10);
             messages.push(Histogram::generated_message_descriptor_data());
             messages.push(Summary::generated_message_descriptor_data());
             messages.push(DownstreamId::generated_message_descriptor_data());
+            messages.push(BulkTimer::generated_message_descriptor_data());
             messages.push(Metric::generated_message_descriptor_data());
             messages.push(MetricSource::generated_message_descriptor_data());
             messages.push(TagValue::generated_message_descriptor_data());

--- a/pulse-protobuf/thirdparty/validate/validate.proto
+++ b/pulse-protobuf/thirdparty/validate/validate.proto
@@ -1,0 +1,862 @@
+syntax = "proto2";
+package validate;
+
+option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
+option java_package = "io.envoyproxy.pgv.validate";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+// Validation rules applied at the message level
+extend google.protobuf.MessageOptions {
+    // Disabled nullifies any validation rules for this message, including any
+    // message fields associated with it that do support validation.
+    optional bool disabled = 1071;
+    // Ignore skips generation of validation methods for this message.
+    optional bool ignored = 1072;
+}
+
+// Validation rules applied at the oneof level
+extend google.protobuf.OneofOptions {
+    // Required ensures that exactly one the field options in a oneof is set;
+    // validation fails if no fields in the oneof are set.
+    optional bool required = 1071;
+}
+
+// Validation rules applied at the field level
+extend google.protobuf.FieldOptions {
+    // Rules specify the validations to be performed on this field. By default,
+    // no validation is performed against a field.
+    optional FieldRules rules = 1071;
+}
+
+// FieldRules encapsulates the rules for each type of field. Depending on the
+// field, the correct set should be used to ensure proper validations.
+message FieldRules {
+    optional MessageRules message = 17;
+    oneof type {
+        // Scalar Field Types
+        FloatRules    float    = 1;
+        DoubleRules   double   = 2;
+        Int32Rules    int32    = 3;
+        Int64Rules    int64    = 4;
+        UInt32Rules   uint32   = 5;
+        UInt64Rules   uint64   = 6;
+        SInt32Rules   sint32   = 7;
+        SInt64Rules   sint64   = 8;
+        Fixed32Rules  fixed32  = 9;
+        Fixed64Rules  fixed64  = 10;
+        SFixed32Rules sfixed32 = 11;
+        SFixed64Rules sfixed64 = 12;
+        BoolRules     bool     = 13;
+        StringRules   string   = 14;
+        BytesRules    bytes    = 15;
+
+        // Complex Field Types
+        EnumRules     enum     = 16;
+        RepeatedRules repeated = 18;
+        MapRules      map      = 19;
+
+        // Well-Known Field Types
+        AnyRules       any       = 20;
+        DurationRules  duration  = 21;
+        TimestampRules timestamp = 22;
+    }
+}
+
+// FloatRules describes the constraints applied to `float` values
+message FloatRules {
+    // Const specifies that this field must be exactly the specified value
+    optional float const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional float lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional float lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional float gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional float gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated float in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated float not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// DoubleRules describes the constraints applied to `double` values
+message DoubleRules {
+    // Const specifies that this field must be exactly the specified value
+    optional double const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional double lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional double lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional double gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional double gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated double in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated double not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Int32Rules describes the constraints applied to `int32` values
+message Int32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Int64Rules describes the constraints applied to `int64` values
+message Int64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// UInt32Rules describes the constraints applied to `uint32` values
+message UInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// UInt64Rules describes the constraints applied to `uint64` values
+message UInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SInt32Rules describes the constraints applied to `sint32` values
+message SInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SInt64Rules describes the constraints applied to `sint64` values
+message SInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Fixed32Rules describes the constraints applied to `fixed32` values
+message Fixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// Fixed64Rules describes the constraints applied to `fixed64` values
+message Fixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SFixed32Rules describes the constraints applied to `sfixed32` values
+message SFixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed32 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// SFixed64Rules describes the constraints applied to `sfixed64` values
+message SFixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed64 not_in = 7;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 8;
+}
+
+// BoolRules describes the constraints applied to `bool` values
+message BoolRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bool const = 1;
+}
+
+// StringRules describe the constraints applied to `string` values
+message StringRules {
+    // Const specifies that this field must be exactly the specified value
+    optional string const = 1;
+
+    // Len specifies that this field must be the specified number of
+    // characters (Unicode code points). Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 len = 19;
+
+    // MinLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a minimum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a maximum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 max_len = 3;
+
+    // LenBytes specifies that this field must be the specified number of bytes
+    optional uint64 len_bytes = 20;
+
+    // MinBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_bytes = 4;
+
+    // MaxBytes specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_bytes = 5;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 6;
+
+    // Prefix specifies that this field must have the specified substring at
+    // the beginning of the string.
+    optional string prefix   = 7;
+
+    // Suffix specifies that this field must have the specified substring at
+    // the end of the string.
+    optional string suffix   = 8;
+
+    // Contains specifies that this field must have the specified substring
+    // anywhere in the string.
+    optional string contains = 9;
+
+    // NotContains specifies that this field cannot have the specified substring
+    // anywhere in the string.
+    optional string not_contains = 23;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated string in     = 10;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated string not_in = 11;
+
+    // WellKnown rules provide advanced constraints against common string
+    // patterns
+    oneof well_known {
+        // Email specifies that the field must be a valid email address as
+        // defined by RFC 5322
+        bool email    = 12;
+
+        // Hostname specifies that the field must be a valid hostname as
+        // defined by RFC 1034. This constraint does not support
+        // internationalized domain names (IDNs).
+        bool hostname = 13;
+
+        // Ip specifies that the field must be a valid IP (v4 or v6) address.
+        // Valid IPv6 addresses should not include surrounding square brackets.
+        bool ip       = 14;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address.
+        bool ipv4     = 15;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address. Valid
+        // IPv6 addresses should not include surrounding square brackets.
+        bool ipv6     = 16;
+
+        // Uri specifies that the field must be a valid, absolute URI as defined
+        // by RFC 3986
+        bool uri      = 17;
+
+        // UriRef specifies that the field must be a valid URI as defined by RFC
+        // 3986 and may be relative or absolute.
+        bool uri_ref  = 18;
+
+        // Address specifies that the field must be either a valid hostname as
+        // defined by RFC 1034 (which does not support internationalized domain
+        // names or IDNs), or it can be a valid IP (v4 or v6).
+        bool address  = 21;
+
+        // Uuid specifies that the field must be a valid UUID as defined by
+        // RFC 4122
+        bool uuid     = 22;
+
+        // WellKnownRegex specifies a common well known pattern defined as a regex.
+        KnownRegex well_known_regex = 24;
+    }
+
+  // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
+  // strict header validation.
+  // By default, this is true, and HTTP header validations are RFC-compliant.
+  // Setting to false will enable a looser validations that only disallows
+  // \r\n\0 characters, which can be used to bypass header matching rules.
+  optional bool strict = 25 [default = true];
+
+  // IgnoreEmpty specifies that the validation rules of this field should be
+  // evaluated only if the field is not empty
+  optional bool ignore_empty = 26;
+}
+
+// WellKnownRegex contain some well-known patterns.
+enum KnownRegex {
+  UNKNOWN = 0;
+
+  // HTTP header name as defined by RFC 7230.
+  HTTP_HEADER_NAME = 1;
+
+  // HTTP header value as defined by RFC 7230.
+  HTTP_HEADER_VALUE = 2;
+}
+
+// BytesRules describe the constraints applied to `bytes` values
+message BytesRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bytes const = 1;
+
+    // Len specifies that this field must be the specified number of bytes
+    optional uint64 len = 13;
+
+    // MinLen specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_len = 3;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 4;
+
+    // Prefix specifies that this field must have the specified bytes at the
+    // beginning of the string.
+    optional bytes  prefix   = 5;
+
+    // Suffix specifies that this field must have the specified bytes at the
+    // end of the string.
+    optional bytes  suffix   = 6;
+
+    // Contains specifies that this field must have the specified bytes
+    // anywhere in the string.
+    optional bytes  contains = 7;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated bytes in     = 8;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated bytes not_in = 9;
+
+    // WellKnown rules provide advanced constraints against common byte
+    // patterns
+    oneof well_known {
+        // Ip specifies that the field must be a valid IP (v4 or v6) address in
+        // byte format
+        bool ip   = 10;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address in byte
+        // format
+        bool ipv4 = 11;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address in byte
+        // format
+        bool ipv6 = 12;
+    }
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 14;
+}
+
+// EnumRules describe the constraints applied to enum values
+message EnumRules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const        = 1;
+
+    // DefinedOnly specifies that this field must be only one of the defined
+    // values for this enum, failing on any undefined value.
+    optional bool  defined_only = 2;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in           = 3;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in       = 4;
+}
+
+// MessageRules describe the constraints applied to embedded message values.
+// For message-type fields, validation is performed recursively.
+message MessageRules {
+    // Skip specifies that the validation rules of this field should not be
+    // evaluated
+    optional bool skip     = 1;
+
+    // Required specifies that this field must be set
+    optional bool required = 2;
+}
+
+// RepeatedRules describe the constraints applied to `repeated` values
+message RepeatedRules {
+    // MinItems specifies that this field must have the specified number of
+    // items at a minimum
+    optional uint64 min_items = 1;
+
+    // MaxItems specifies that this field must have the specified number of
+    // items at a maximum
+    optional uint64 max_items = 2;
+
+    // Unique specifies that all elements in this field must be unique. This
+    // contraint is only applicable to scalar and enum types (messages are not
+    // supported).
+    optional bool   unique    = 3;
+
+    // Items specifies the contraints to be applied to each item in the field.
+    // Repeated message fields will still execute validation against each item
+    // unless skip is specified here.
+    optional FieldRules items = 4;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 5;
+}
+
+// MapRules describe the constraints applied to `map` values
+message MapRules {
+    // MinPairs specifies that this field must have the specified number of
+    // KVs at a minimum
+    optional uint64 min_pairs = 1;
+
+    // MaxPairs specifies that this field must have the specified number of
+    // KVs at a maximum
+    optional uint64 max_pairs = 2;
+
+    // NoSparse specifies values in this field cannot be unset. This only
+    // applies to map's with message value types.
+    optional bool no_sparse = 3;
+
+    // Keys specifies the constraints to be applied to each key in the field.
+    optional FieldRules keys   = 4;
+
+    // Values specifies the constraints to be applied to the value of each key
+    // in the field. Message values will still have their validations evaluated
+    // unless skip is specified here.
+    optional FieldRules values = 5;
+
+    // IgnoreEmpty specifies that the validation rules of this field should be
+    // evaluated only if the field is not empty
+    optional bool ignore_empty = 6;
+}
+
+// AnyRules describe constraints applied exclusively to the
+// `google.protobuf.Any` well-known type
+message AnyRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // In specifies that this field's `type_url` must be equal to one of the
+    // specified values.
+    repeated string in     = 2;
+
+    // NotIn specifies that this field's `type_url` must not be equal to any of
+    // the specified values.
+    repeated string not_in = 3;
+}
+
+// DurationRules describe the constraints applied exclusively to the
+// `google.protobuf.Duration` well-known type
+message DurationRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Duration const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Duration lt = 3;
+
+    // Lt specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Duration lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Duration gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Duration gte = 6;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration in = 7;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration not_in = 8;
+}
+
+// TimestampRules describe the constraints applied exclusively to the
+// `google.protobuf.Timestamp` well-known type
+message TimestampRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Timestamp const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp lt = 3;
+
+    // Lte specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp gte = 6;
+
+    // LtNow specifies that this must be less than the current time. LtNow
+    // can only be used with the Within rule.
+    optional bool lt_now  = 7;
+
+    // GtNow specifies that this must be greater than the current time. GtNow
+    // can only be used with the Within rule.
+    optional bool gt_now  = 8;
+
+    // Within specifies that this field must be within this duration of the
+    // current time. This constraint can be used alone or with the LtNow and
+    // GtNow rules.
+    optional google.protobuf.Duration within = 9;
+}

--- a/pulse-proxy/src/test/integration/complex_config.rs
+++ b/pulse-proxy/src/test/integration/complex_config.rs
@@ -354,7 +354,8 @@ pipeline:
       aggregation:
         flush_interval: 1s
         enable_last_aggregation_admin_endpoint: true
-        reservoir_timers: {{}}
+        reservoir_timers:
+          emit_as_bulk_timer: true
 
   outflows:
     wfp:
@@ -537,9 +538,9 @@ async fn all() {
           ("tag_b", "b"),
         ],
         0,
-        Some(MetricType::Timer),
+        Some(MetricType::BulkTimer),
         Some(1.0),
-        MetricValue::Simple(1.0),
+        MetricValue::BulkTimer(vec![1.0]),
         MetricSource::PromRemoteWrite,
         DownstreamId::LocalOrigin,
         None,

--- a/pulse-proxy/src/test/integration/dynamic_fs_config.rs
+++ b/pulse-proxy/src/test/integration/dynamic_fs_config.rs
@@ -107,7 +107,9 @@ async fn reload_config() {
   .await;
   let client = PromClient::new(bind_resolver.local_tcp_addr("inflow:prom")).await;
 
-  client.send(&[make_abs_counter("hello", &[], 1, 1.0)]).await;
+  client
+    .send(vec![make_abs_counter("hello", &[], 1, 1.0)])
+    .await;
   assert_eq!(
     vec![make_abs_counter("hello", &[], 1, 1.0)],
     upstream.wait_for_metrics().await.1
@@ -124,7 +126,9 @@ async fn reload_config() {
 
   // Use a fresh client as the previous client's connection may race with the old inflow shutdown.
   let client = PromClient::new(bind_resolver.local_tcp_addr("inflow:prom")).await;
-  client.send(&[make_abs_counter("world", &[], 1, 1.0)]).await;
+  client
+    .send(vec![make_abs_counter("world", &[], 1, 1.0)])
+    .await;
   assert_eq!(
     vec![make_abs_counter("world", &[], 1, 1.0)],
     upstream.wait_for_metrics().await.1
@@ -162,7 +166,9 @@ async fn bad_config() {
     .wait_for_counter_eq(1, "pulse_proxy:config:failed_update", &labels! {})
     .await;
 
-  client.send(&[make_abs_counter("world", &[], 1, 1.0)]).await;
+  client
+    .send(vec![make_abs_counter("world", &[], 1, 1.0)])
+    .await;
   assert_eq!(
     vec![make_abs_counter("world", &[], 1, 1.0)],
     upstream.wait_for_metrics().await.1

--- a/pulse-proxy/src/test/integration/mod.rs
+++ b/pulse-proxy/src/test/integration/mod.rs
@@ -534,7 +534,7 @@ impl PromClient {
     }
   }
 
-  async fn send(&self, metrics: &[ParsedMetric]) {
+  async fn send(&self, metrics: Vec<ParsedMetric>) {
     let write_request = to_write_request(
       metrics,
       &ToWriteRequestOptions {

--- a/pulse-proxy/src/test/integration/prom.rs
+++ b/pulse-proxy/src/test/integration/prom.rs
@@ -82,7 +82,7 @@ async fn remote_write() {
         )
       })
       .collect_vec();
-    client.send(&metrics).await;
+    client.send(metrics).await;
   }
 
   assert_eq!(
@@ -193,13 +193,13 @@ async fn lyft_remote_write() {
   .await;
   let client = PromClient::new(bind_resolver.local_tcp_addr("inflow:prom")).await;
 
-  client.send(&[make_metric("foo", &[], 1)]).await;
+  client.send(vec![make_metric("foo", &[], 1)]).await;
   let headers = expect_metric(&mut upstream1, "foo", make_metric("foo", &[], 1)).await;
   assert_eq!(headers.get("extra").unwrap(), "header");
   expect_metric(&mut upstream2, "blah", make_metric("foo", &[], 1)).await;
 
   client
-    .send(&[make_metric("foo:host", &[("host", "foo")], 1)])
+    .send(vec![make_metric("foo:host", &[("host", "foo")], 1)])
     .await;
   upstream1.add_failure_response_code(StatusCode::INTERNAL_SERVER_ERROR);
   expect_metric(
@@ -216,7 +216,7 @@ async fn lyft_remote_write() {
   .await;
 
   client
-    .send(&[make_metric(
+    .send(vec![make_metric(
       "foo:infra:aws:blah",
       &[("source", "non_statsd")],
       1,
@@ -238,7 +238,7 @@ async fn lyft_remote_write() {
   upstream1.add_failure_response_code(StatusCode::BAD_REQUEST);
   upstream2.add_failure_response_code(StatusCode::BAD_REQUEST);
   client
-    .send(&[make_metric(
+    .send(vec![make_metric(
       "foo:infra:aws:blah",
       &[("source", "non_statsd")],
       1,


### PR DESCRIPTION
This change introduces a "bulk timer" type which is designed to carry along statsd style timers in a single pseudo metric to avoid repeated processing of the same metric name, tags, etc. over and over again. This has been implemented for both internode as well as a prom remote write extension.

By default the pre-buffer functionality will internally emit bulk timers out of the reservoir. In order to emit bulk timers out of the aggregation processor reservoir, configure the new `emit_as_bulk_timer` option.

Additionally, new bitdrift extensions for prom remote write have been added for delta counters and statsd timers, so the inflow options for `summary_as_timer` and `counter_as_delta` are no longer needed if receiving traffic from supporting pulse instances.

Finally, statsd set support has been removed as it's unused anywhere we know of.

Fixes BIT-4330