### PR TITLE
build: pin to 22.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,8 +49,8 @@ jobs:
     strategy:
       matrix:
         os: [
-          {runner: ubuntu-latest-16-cores, arch: linux/amd64, tag_suffix: amd64},
-          {runner: ubuntu-latest-arm-16-cores, arch: linux/arm64, tag_suffix: arm64},
+          {runner: ubuntu-2204-16-cores, arch: linux/amd64, tag_suffix: amd64},
+          {runner: ubuntu-2204-arm-16-cores, arch: linux/arm64, tag_suffix: arm64},
         ]
     name: build
     permissions:


### PR DESCRIPTION
GHA recently bumped to 24.04 and we would like to stick to older glibc for now.