### PR TITLE
prom scraping: support multiple ports and inclusion rules

### DIFF
--- a/pulse-common/src/k8s/test/mod.rs
+++ b/pulse-common/src/k8s/test/mod.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use super::pods_info::{PodInfo, PromEndpoint, ServiceInfo};
+use super::pods_info::{ContainerPort, PodInfo, ServiceInfo};
 use crate::metadata::Metadata;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -17,9 +17,9 @@ pub fn make_pod_info(
   name: &str,
   labels: &BTreeMap<String, String>,
   annotations: BTreeMap<String, String>,
-  prom_endpoint: Option<PromEndpoint>,
   services: HashMap<String, Arc<ServiceInfo>>,
   ip: &str,
+  container_ports: Vec<ContainerPort>,
 ) -> PodInfo {
   let metadata = Arc::new(Metadata::new(
     namespace,
@@ -33,15 +33,15 @@ pub fn make_pod_info(
     None,
   ));
   PodInfo {
-    name: name.to_string().into(),
-    namespace: namespace.to_string().into(),
-    prom_endpoint,
+    name: name.to_string(),
+    namespace: namespace.to_string(),
     services,
     ip: ip.parse().unwrap(),
-    annotations: annotations
-      .into_iter()
-      .map(|(k, v)| (k.into(), v.into()))
-      .collect(),
+    labels: labels.clone(),
+    annotations,
     metadata,
+    container_ports,
+    node_name: "node".to_string(),
+    node_ip: "node_ip".to_string(),
   }
 }

--- a/pulse-metrics/src/pipeline/processor/cardinality_limiter/mod_test.rs
+++ b/pulse-metrics/src/pipeline/processor/cardinality_limiter/mod_test.rs
@@ -50,9 +50,9 @@ async fn all_per_pod() {
     "pod1",
     &BTreeMap::default(),
     BTreeMap::default(),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   helper.k8s_sender.send(pods_info.clone()).unwrap();
 
@@ -119,9 +119,9 @@ async fn all_per_pod() {
     "pod2",
     &BTreeMap::default(),
     btreemap!("cardinality_limit" => "3"),
-    None,
     HashMap::default(),
     "127.0.0.2",
+    vec![],
   ));
   helper.k8s_sender.send(pods_info.clone()).unwrap();
   yield_now().await;

--- a/pulse-protobuf/proto/pulse/config/inflow/v1/k8s_prom.proto
+++ b/pulse-protobuf/proto/pulse/config/inflow/v1/k8s_prom.proto
@@ -17,7 +17,7 @@ message KubernetesPrometheusConfig {
   // How often eligible Prometheus endpoints are scraped.
   google.protobuf.Duration scrape_interval = 1 [(validate.rules).message.required = true];
 
-  // Scrapes metrics from Prometheues endpoints defined on pods via associated service annotations.
+  // Scrapes metrics from Prometheus endpoints defined on pods via associated service annotations.
   // Resolves to all pod-local endpoints using the service annotations to infer path, port, etc.
   message Endpoint {
   }
@@ -31,6 +31,20 @@ message KubernetesPrometheusConfig {
 
   // Scrapes metrics from Prometheus endpoints defined on pods via pod annotations.
   message Pod {
+    message InclusionFilter {
+      oneof filter_type {
+        option (validate.required) = true;
+
+        // Apply the following regex to each container port name to determine if it should be
+        // scraped. If the regex is a match, the container port will be scraped.
+        string container_port_name_regex = 1;
+      }
+    }
+
+    // Inclusion filters can be used to include pods to be scraped even if they do not have the
+    // standard Prometheus annotations. An inclusion filter if successful will result in a container
+    // port to be scraped.
+    repeated InclusionFilter inclusion_filters = 1;
   }
 
   oneof target {

--- a/pulse-protobuf/src/protos/pulse/config/inflow/v1/k8s_prom.rs
+++ b/pulse-protobuf/src/protos/pulse/config/inflow/v1/k8s_prom.rs
@@ -624,6 +624,9 @@ pub mod kubernetes_prometheus_config {
     // @@protoc_insertion_point(message:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod)
     #[derive(PartialEq,Clone,Default,Debug)]
     pub struct Pod {
+        // message fields
+        // @@protoc_insertion_point(field:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.inclusion_filters)
+        pub inclusion_filters: ::std::vec::Vec<pod::InclusionFilter>,
         // special fields
         // @@protoc_insertion_point(special_field:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.special_fields)
         pub special_fields: ::protobuf::SpecialFields,
@@ -641,8 +644,13 @@ pub mod kubernetes_prometheus_config {
         }
 
         pub(in super) fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-            let mut fields = ::std::vec::Vec::with_capacity(0);
+            let mut fields = ::std::vec::Vec::with_capacity(1);
             let mut oneofs = ::std::vec::Vec::with_capacity(0);
+            fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
+                "inclusion_filters",
+                |m: &Pod| { &m.inclusion_filters },
+                |m: &mut Pod| { &mut m.inclusion_filters },
+            ));
             ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<Pod>(
                 "KubernetesPrometheusConfig.Pod",
                 fields,
@@ -661,6 +669,9 @@ pub mod kubernetes_prometheus_config {
         fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
             while let Some(tag) = is.read_raw_tag_or_eof()? {
                 match tag {
+                    10 => {
+                        self.inclusion_filters.push(is.read_message()?);
+                    },
                     tag => {
                         ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                     },
@@ -673,12 +684,19 @@ pub mod kubernetes_prometheus_config {
         #[allow(unused_variables)]
         fn compute_size(&self) -> u64 {
             let mut my_size = 0;
+            for value in &self.inclusion_filters {
+                let len = value.compute_size();
+                my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+            };
             my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
             self.special_fields.cached_size().set(my_size as u32);
             my_size
         }
 
         fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+            for v in &self.inclusion_filters {
+                ::protobuf::rt::write_message_field_with_cached_size(1, v, os)?;
+            };
             os.write_unknown_fields(self.special_fields.unknown_fields())?;
             ::std::result::Result::Ok(())
         }
@@ -696,11 +714,13 @@ pub mod kubernetes_prometheus_config {
         }
 
         fn clear(&mut self) {
+            self.inclusion_filters.clear();
             self.special_fields.clear();
         }
 
         fn default_instance() -> &'static Pod {
             static instance: Pod = Pod {
+                inclusion_filters: ::std::vec::Vec::new(),
                 special_fields: ::protobuf::SpecialFields::new(),
             };
             &instance
@@ -723,12 +743,222 @@ pub mod kubernetes_prometheus_config {
     impl ::protobuf::reflect::ProtobufValue for Pod {
         type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
     }
+
+    /// Nested message and enums of message `Pod`
+    pub mod pod {
+        // @@protoc_insertion_point(message:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.InclusionFilter)
+        #[derive(PartialEq,Clone,Default,Debug)]
+        pub struct InclusionFilter {
+            // message oneof groups
+            pub filter_type: ::std::option::Option<inclusion_filter::Filter_type>,
+            // special fields
+            // @@protoc_insertion_point(special_field:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.InclusionFilter.special_fields)
+            pub special_fields: ::protobuf::SpecialFields,
+        }
+
+        impl<'a> ::std::default::Default for &'a InclusionFilter {
+            fn default() -> &'a InclusionFilter {
+                <InclusionFilter as ::protobuf::Message>::default_instance()
+            }
+        }
+
+        impl InclusionFilter {
+            pub fn new() -> InclusionFilter {
+                ::std::default::Default::default()
+            }
+
+            // string container_port_name_regex = 1;
+
+            pub fn container_port_name_regex(&self) -> &str {
+                match self.filter_type {
+                    ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(ref v)) => v,
+                    _ => "",
+                }
+            }
+
+            pub fn clear_container_port_name_regex(&mut self) {
+                self.filter_type = ::std::option::Option::None;
+            }
+
+            pub fn has_container_port_name_regex(&self) -> bool {
+                match self.filter_type {
+                    ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(..)) => true,
+                    _ => false,
+                }
+            }
+
+            // Param is passed by value, moved
+            pub fn set_container_port_name_regex(&mut self, v: ::protobuf::Chars) {
+                self.filter_type = ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(v))
+            }
+
+            // Mutable pointer to the field.
+            pub fn mut_container_port_name_regex(&mut self) -> &mut ::protobuf::Chars {
+                if let ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(_)) = self.filter_type {
+                } else {
+                    self.filter_type = ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(::protobuf::Chars::new()));
+                }
+                match self.filter_type {
+                    ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(ref mut v)) => v,
+                    _ => panic!(),
+                }
+            }
+
+            // Take field
+            pub fn take_container_port_name_regex(&mut self) -> ::protobuf::Chars {
+                if self.has_container_port_name_regex() {
+                    match self.filter_type.take() {
+                        ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(v)) => v,
+                        _ => panic!(),
+                    }
+                } else {
+                    ::protobuf::Chars::new()
+                }
+            }
+
+            pub(in super::super) fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+                let mut fields = ::std::vec::Vec::with_capacity(1);
+                let mut oneofs = ::std::vec::Vec::with_capacity(1);
+                fields.push(::protobuf::reflect::rt::v2::make_oneof_deref_has_get_set_simpler_accessor::<_, _>(
+                    "container_port_name_regex",
+                    InclusionFilter::has_container_port_name_regex,
+                    InclusionFilter::container_port_name_regex,
+                    InclusionFilter::set_container_port_name_regex,
+                ));
+                oneofs.push(inclusion_filter::Filter_type::generated_oneof_descriptor_data());
+                ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<InclusionFilter>(
+                    "KubernetesPrometheusConfig.Pod.InclusionFilter",
+                    fields,
+                    oneofs,
+                )
+            }
+        }
+
+        impl ::protobuf::Message for InclusionFilter {
+            const NAME: &'static str = "InclusionFilter";
+
+            fn is_initialized(&self) -> bool {
+                true
+            }
+
+            fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+                while let Some(tag) = is.read_raw_tag_or_eof()? {
+                    match tag {
+                        10 => {
+                            self.filter_type = ::std::option::Option::Some(inclusion_filter::Filter_type::ContainerPortNameRegex(is.read_tokio_chars()?));
+                        },
+                        tag => {
+                            ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                        },
+                    };
+                }
+                ::std::result::Result::Ok(())
+            }
+
+            // Compute sizes of nested messages
+            #[allow(unused_variables)]
+            fn compute_size(&self) -> u64 {
+                let mut my_size = 0;
+                if let ::std::option::Option::Some(ref v) = self.filter_type {
+                    match v {
+                        &inclusion_filter::Filter_type::ContainerPortNameRegex(ref v) => {
+                            my_size += ::protobuf::rt::string_size(1, &v);
+                        },
+                    };
+                }
+                my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+                self.special_fields.cached_size().set(my_size as u32);
+                my_size
+            }
+
+            fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+                if let ::std::option::Option::Some(ref v) = self.filter_type {
+                    match v {
+                        &inclusion_filter::Filter_type::ContainerPortNameRegex(ref v) => {
+                            os.write_string(1, v)?;
+                        },
+                    };
+                }
+                os.write_unknown_fields(self.special_fields.unknown_fields())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn special_fields(&self) -> &::protobuf::SpecialFields {
+                &self.special_fields
+            }
+
+            fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+                &mut self.special_fields
+            }
+
+            fn new() -> InclusionFilter {
+                InclusionFilter::new()
+            }
+
+            fn clear(&mut self) {
+                self.filter_type = ::std::option::Option::None;
+                self.special_fields.clear();
+            }
+
+            fn default_instance() -> &'static InclusionFilter {
+                static instance: InclusionFilter = InclusionFilter {
+                    filter_type: ::std::option::Option::None,
+                    special_fields: ::protobuf::SpecialFields::new(),
+                };
+                &instance
+            }
+        }
+
+        impl ::protobuf::MessageFull for InclusionFilter {
+            fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+                static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+                descriptor.get(|| super::super::file_descriptor().message_by_package_relative_name("KubernetesPrometheusConfig.Pod.InclusionFilter").unwrap()).clone()
+            }
+        }
+
+        impl ::std::fmt::Display for InclusionFilter {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                ::protobuf::text_format::fmt(self, f)
+            }
+        }
+
+        impl ::protobuf::reflect::ProtobufValue for InclusionFilter {
+            type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+        }
+
+        /// Nested message and enums of message `InclusionFilter`
+        pub mod inclusion_filter {
+
+            #[derive(Clone,PartialEq,Debug)]
+            // @@protoc_insertion_point(oneof:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.InclusionFilter.filter_type)
+            pub enum Filter_type {
+                // @@protoc_insertion_point(oneof_field:pulse.config.inflow.v1.KubernetesPrometheusConfig.Pod.InclusionFilter.container_port_name_regex)
+                ContainerPortNameRegex(::protobuf::Chars),
+            }
+
+            impl ::protobuf::Oneof for Filter_type {
+            }
+
+            impl ::protobuf::OneofFull for Filter_type {
+                fn descriptor() -> ::protobuf::reflect::OneofDescriptor {
+                    static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::OneofDescriptor> = ::protobuf::rt::Lazy::new();
+                    descriptor.get(|| <super::InclusionFilter as ::protobuf::MessageFull>::descriptor().oneof_by_name("filter_type").unwrap()).clone()
+                }
+            }
+
+            impl Filter_type {
+                pub(in super::super::super) fn generated_oneof_descriptor_data() -> ::protobuf::reflect::GeneratedOneofDescriptorData {
+                    ::protobuf::reflect::GeneratedOneofDescriptorData::new::<Filter_type>("filter_type")
+                }
+            }
+        }
+    }
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n%pulse/config/inflow/v1/k8s_prom.proto\x12\x16pulse.config.inflow.v1\
     \x1a\x1egoogle/protobuf/duration.proto\x1a\x17validate/validate.proto\"\
-    \xa7\x03\n\x1aKubernetesPrometheusConfig\x12L\n\x0fscrape_interval\x18\
+    \x81\x05\n\x1aKubernetesPrometheusConfig\x12L\n\x0fscrape_interval\x18\
     \x01\x20\x01(\x0b2\x19.google.protobuf.DurationR\x0escrapeIntervalB\x08\
     \xfaB\x05\x8a\x01\x02\x10\x01\x12Y\n\x08endpoint\x18\x02\x20\x01(\x0b2;.\
     pulse.config.inflow.v1.KubernetesPrometheusConfig.EndpointH\0R\x08endpoi\
@@ -736,8 +966,12 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     esPrometheusConfig.NodeH\0R\x04node\x12J\n\x03pod\x18\x04\x20\x01(\x0b26\
     .pulse.config.inflow.v1.KubernetesPrometheusConfig.PodH\0R\x03pod\x1a\n\
     \n\x08Endpoint\x1a#\n\x04Node\x12\x1b\n\x04path\x18\x01\x20\x01(\tR\x04p\
-    athB\x07\xfaB\x04r\x02\x10\x01\x1a\x05\n\x03PodB\r\n\x06target\x12\x03\
-    \xf8B\x01b\x06proto3\
+    athB\x07\xfaB\x04r\x02\x10\x01\x1a\xde\x01\n\x03Pod\x12s\n\x11inclusion_\
+    filters\x18\x01\x20\x03(\x0b2F.pulse.config.inflow.v1.KubernetesPromethe\
+    usConfig.Pod.InclusionFilterR\x10inclusionFilters\x1ab\n\x0fInclusionFil\
+    ter\x12;\n\x19container_port_name_regex\x18\x01\x20\x01(\tH\0R\x16contai\
+    nerPortNameRegexB\x12\n\x0bfilter_type\x12\x03\xf8B\x01B\r\n\x06target\
+    \x12\x03\xf8B\x01b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -757,11 +991,12 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             let mut deps = ::std::vec::Vec::with_capacity(2);
             deps.push(::protobuf::well_known_types::duration::file_descriptor().clone());
             deps.push(super::validate::file_descriptor().clone());
-            let mut messages = ::std::vec::Vec::with_capacity(4);
+            let mut messages = ::std::vec::Vec::with_capacity(5);
             messages.push(KubernetesPrometheusConfig::generated_message_descriptor_data());
             messages.push(kubernetes_prometheus_config::Endpoint::generated_message_descriptor_data());
             messages.push(kubernetes_prometheus_config::Node::generated_message_descriptor_data());
             messages.push(kubernetes_prometheus_config::Pod::generated_message_descriptor_data());
+            messages.push(kubernetes_prometheus_config::pod::InclusionFilter::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),

--- a/pulse-proxy/src/test/integration/complex_config.rs
+++ b/pulse-proxy/src/test/integration/complex_config.rs
@@ -412,9 +412,9 @@ async fn all() {
       "service_instance" => "production",
       "ec2_region_shortname" => "xyz"
     ),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
   let az_env_var = Uuid::new_v4().to_string();

--- a/pulse-proxy/src/test/integration/statsd.rs
+++ b/pulse-proxy/src/test/integration/statsd.rs
@@ -124,9 +124,9 @@ async fn udp_k8s_pod_metadata() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 
@@ -202,9 +202,9 @@ async fn udp_k8s_pre_buffer() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 
@@ -296,9 +296,9 @@ async fn tcp_k8s_pod_metadata() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 
@@ -401,9 +401,9 @@ async fn tcp_k8s_prebuffer() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 
@@ -474,9 +474,9 @@ async fn tcp_k8s_prebuffer_early_shutdown() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 
@@ -565,9 +565,9 @@ async fn tcp_k8s_always_prebuffer() {
     "pod_a",
     &btreemap!("foo" => "bar"),
     btreemap!("foo" => "baz"),
-    None,
     HashMap::default(),
     "127.0.0.1",
+    vec![],
   ));
   let (_pods_tx, pods_rx) = watch::channel(pods_info);
 


### PR DESCRIPTION
1) Refactor pods info to move scraping logic to the scraper. 
2) Support multiple ports in the prom port annotation. 
3) Support port inclusion via regex.

Fixes BIT-4713