### PR TITLE
support service target ports that use names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
  "hyperloglogplus",
  "intrusive-collections",
  "itertools 0.14.0",
+ "k8s-openapi",
  "log",
  "matches",
  "memchr",

--- a/pulse-common/src/k8s/pods_info.rs
+++ b/pulse-common/src/k8s/pods_info.rs
@@ -360,7 +360,7 @@ pub struct ServiceInfo {
   pub name: String,
   pub annotations: BTreeMap<String, String>,
   pub selector: BTreeMap<String, String>,
-  pub maybe_service_port: Option<i32>,
+  pub maybe_service_port: Option<IntOrString>,
 }
 
 pub async fn service_watch_stream() -> anyhow::Result<
@@ -561,12 +561,12 @@ struct ServiceCache {
 
 impl ServiceCache {
   fn apply_service(&mut self, service: Service) {
-    let maybe_service_port = service.spec.as_ref().and_then(|spec| {
-      Some(match spec.ports.as_ref()?.first()?.target_port.as_ref()? {
-        IntOrString::Int(i) => *i,
-        IntOrString::String(s) => s.parse().ok()?,
-      })
-    });
+    let maybe_service_port = service.spec
+      .as_ref()
+      .and_then(|spec| spec.ports.as_ref())
+      .and_then(|ports| ports.first())
+      .map(|port| port.target_port.clone())
+      .flatten();
 
     self
       .services_by_namespace

--- a/pulse-common/src/k8s/pods_info_test.rs
+++ b/pulse-common/src/k8s/pods_info_test.rs
@@ -10,6 +10,7 @@ use crate::k8s::pods_info::{ContainerPort, PodsInfo, ServiceInfo, ServiceMonitor
 use crate::k8s::test::make_pod_info;
 use k8s_openapi::api::core::v1;
 use k8s_openapi::api::core::v1::{Container, Pod, PodSpec, PodStatus};
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::core::ObjectMeta;
 use pretty_assertions::assert_eq;
 use std::collections::{BTreeMap, HashMap};
@@ -76,7 +77,7 @@ fn pod_cache() {
           selector: btreemap! {
             "service" => "svc2"
           },
-          maybe_service_port: Some(4321),
+          maybe_service_port: Some(IntOrString::Int(4321)),
         }),
       ),
     ]),
@@ -200,7 +201,7 @@ fn pod_cache() {
           selector: btreemap! {
             "service" => "svc2"
           },
-          maybe_service_port: Some(4321),
+          maybe_service_port: Some(IntOrString::Int(4321)),
         }),
       )]),
       "127.0.0.2",

--- a/pulse-metrics/Cargo.toml
+++ b/pulse-metrics/Cargo.toml
@@ -49,6 +49,7 @@ hyper.workspace                  = true
 hyperloglogplus.workspace        = true
 intrusive-collections.workspace  = true
 itertools.workspace              = true
+k8s-openapi.workspace            = true
 log.workspace                    = true
 memchr.workspace                 = true
 mockall.workspace                = true


### PR DESCRIPTION
https://kube-api.ninja/apidocs/1.33/#serviceport-v1-core

> targetPort | Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service

it's common for service ports to use container port names for target port for example,
```
  ports:
  - name: http-metrics
    port: 8000
    protocol: TCP
    targetPort: http-metrics
```

By definition in the api if the targetPort is string, it must be name of container port defined in the target pods.

So this change supports services that uses that configuration.

the port resolution is still the same, 
1. if ports are selection with inclusion filter or prometheus.io/port --> use them first
2. if service_port is known try to find the correct port -> this is second
3. if all fails use 9090