### PR TITLE
aggregation: make gauge sum/mean depend on downstream ID

### DIFF
--- a/pulse-metrics/src/pipeline/processor/aggregation/mod_test.rs
+++ b/pulse-metrics/src/pipeline/processor/aggregation/mod_test.rs
@@ -675,9 +675,30 @@ async fn gauges() {
   let mut helper = HelperBuilder::default().extended_gauges().build().await;
   helper
     .recv(vec![
-      helper.make_metric("hello", MetricType::Gauge, MetricValue::Simple(5.0)),
-      helper.make_metric("world", MetricType::DeltaGauge, MetricValue::Simple(5.0)),
-      helper.make_metric("foo", MetricType::DirectGauge, MetricValue::Simple(100.0)),
+      helper.make_metric_ex(
+        "hello",
+        Some(MetricType::Gauge),
+        None,
+        MetricValue::Simple(5.0),
+        MetricSource::PromRemoteWrite,
+        DownstreamId::InflowProvided("1".into()),
+      ),
+      helper.make_metric_ex(
+        "world",
+        Some(MetricType::DeltaGauge),
+        None,
+        MetricValue::Simple(5.0),
+        MetricSource::PromRemoteWrite,
+        DownstreamId::InflowProvided("1".into()),
+      ),
+      helper.make_metric_ex(
+        "foo",
+        Some(MetricType::DirectGauge),
+        None,
+        MetricValue::Simple(100.0),
+        MetricSource::PromRemoteWrite,
+        DownstreamId::InflowProvided("1".into()),
+      ),
     ])
     .await;
   helper

--- a/pulse-protobuf/proto/pulse/config/processor/v1/aggregation.proto
+++ b/pulse-protobuf/proto/pulse/config/processor/v1/aggregation.proto
@@ -97,8 +97,12 @@ message AggregationConfig {
     // Extended output configuration for gauges.
     message Extended {
       // The sum of samples during the interval.
+      // Important note: For this to work correctly the incoming gauges must have unique downstream
+      // IDs so that they can be differentiated.
       bool sum = 1;
       // The mean of samples during the interval.
+      // Important note: For this to work correctly the incoming gauges must have unique downstream
+      // IDs so that they can be differentiated.
       bool mean = 2;
       // The minimum sample during the interval.
       bool min = 3;


### PR DESCRIPTION
Without this the values have no real meaning. Warnings have been added to the config. This means that Each repeated gauge value during an interval must have a unique downstream ID for this to work properly.