### PR TITLE
otlp: add option to convert to prometheus names on outflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,12 +140,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -265,9 +265,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fcc63c9860579e4cb396239570e979376e70aab79e496621748a09913f8b36"
+checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.67.0"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f15bedfb1c4385fccc474f0fe46dffb0335d0b3d6b4413df06fb30d90caba8"
+checksum = "b742e0981caafc34a57b36d6e492786e2a11638766f49e1c92dec1b55f33d16b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -370,16 +370,15 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.67.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4863da26489d1e6da91d7e12b10c17e86c14f94c53f416bd10e0a9c34057ba"
+checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -393,16 +392,15 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.68.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95caa3998d7237789b57b95a8e031f60537adab21fa84c91e35bef9455c652e4"
+checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -416,16 +414,15 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.68.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4939f6f449a37308a78c5a910fd91265479bd2bb11d186f0b8fc114d89ec828d"
+checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -440,16 +437,15 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
+checksum = "3734aecf9ff79aa401a6ca099d076535ab465ff76b46440cf567c8e70b65dc13"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -514,7 +510,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -865,17 +861,20 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bd-client-stats-store",
  "bd-log-primitives",
  "bd-matcher",
  "bd-metadata",
  "bd-proto",
+ "crc32fast",
  "flatbuffers",
  "flate2",
  "log",
+ "mockall",
  "parking_lot",
  "protobuf 4.0.0-alpha.0",
  "thiserror 2.0.12",
@@ -887,7 +886,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -902,7 +901,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -914,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -955,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -970,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -982,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -997,7 +996,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -1014,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -1024,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -1036,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -1049,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1064,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "color-backtrace",
  "log",
@@ -1074,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "log",
  "protobuf 4.0.0-alpha.0",
@@ -1085,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -1098,12 +1097,13 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "base64ct",
  "bd-proto",
  "cc",
+ "flatbuffers",
  "itertools 0.14.0",
  "protobuf 4.0.0-alpha.0",
  "sha2",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -1129,12 +1129,14 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bd-client-common",
  "bd-proto",
  "log",
+ "parking_lot",
  "protobuf 4.0.0-alpha.0",
  "time",
  "tokio",
@@ -1143,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime-config"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "async-trait",
  "bd-server-stats",
@@ -1161,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -1180,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1200,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1221,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "log",
  "tokio",
@@ -1230,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "sketches-rust",
 ]
@@ -1238,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1280,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git#6e0ca2497ddb5de910121a7cbd7e26285f518598"
+source = "git+https://github.com/bitdriftlabs/shared-core.git#6a00a3df3beb900570d54f94d2da736bc5d5c149"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -1316,7 +1318,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1356,9 +1358,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -1489,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1667,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1677,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1846,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1880,25 +1882,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1954,7 +1953,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -2158,6 +2157,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,9 +2368,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2408,7 +2427,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "rustc_version 0.4.1",
 ]
 
@@ -2587,10 +2606,11 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
@@ -2669,7 +2689,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -2832,12 +2852,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -3004,7 +3018,7 @@ dependencies = [
  "headers",
  "http 1.3.1",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
@@ -3031,11 +3045,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
@@ -3046,7 +3059,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -3064,12 +3077,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -3103,7 +3117,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3164,9 +3178,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3180,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -3283,7 +3297,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -3330,17 +3344,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.1",
- "libc",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3456,14 +3459,13 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "serde",
- "serde-value",
  "serde_json",
 ]
 
@@ -3498,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.99.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
+checksum = "778f98664beaf4c3c11372721e14310d1ae00f5e2d9aabcf8906c881aa4e9f51"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3511,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.99.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
+checksum = "7cb276b85b6e94ded00ac8ea2c68fcf4697ea0553cb25fddc35d4a0ab718db8d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3526,7 +3528,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-http-proxy",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
@@ -3548,11 +3550,12 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.99.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
+checksum = "e3c56ff45deb0031f2a476017eed60c06872251f271b8387ad8020b8fef60960"
 dependencies = [
  "chrono",
+ "derive_more 2.0.1",
  "form_urlencoded",
  "http 1.3.1",
  "json-patch",
@@ -3566,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.99.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
+checksum = "079fc8c1c397538628309cfdee20696ebdcc26745f9fb17f89b78782205bd995"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3580,14 +3583,13 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.99.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
+checksum = "2f1326e946fadf6248febdf8a1c001809c3899ccf48cb9768cbc536b741040dc"
 dependencies = [
  "ahash 0.8.12",
  "async-broadcast",
  "async-stream",
- "async-trait",
  "backon",
  "educe",
  "futures",
@@ -3668,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -3682,7 +3684,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -3827,14 +3829,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3916,7 +3918,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -3985,7 +3987,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4067,12 +4069,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4080,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4498,7 +4506,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -4510,7 +4518,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "hex",
 ]
 
@@ -4668,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.107"
+version = "2.1.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d3257075f822569e43169391d51c0483196d37dc21c14807228f4dd1a76545"
+checksum = "1c6b4c497a0c6bfb466f75167c728b1a861b0cdc39de9c35b877208a270a9590"
 dependencies = [
  "psl-types",
 ]
@@ -4796,7 +4804,7 @@ dependencies = [
  "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "hyperloglogplus",
  "intrusive-collections",
@@ -5195,7 +5203,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -5282,7 +5290,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5427,7 +5435,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5440,7 +5448,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5564,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -5668,7 +5676,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5681,8 +5689,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5963,9 +5971,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6271,9 +6279,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6474,7 +6482,7 @@ version = "0.6.2"
 source = "git+https://github.com/tower-rs/tower-http?rev=d0c522b6da2620bf5314302d12e4cded7295b11c#d0c522b6da2620bf5314302d12e4cded7295b11c"
 dependencies = [
  "async-compression",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "http 1.3.1",
@@ -6493,7 +6501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -6606,7 +6614,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.20",
  "lazy_static",
  "regex",
  "serde",
@@ -6736,9 +6744,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -7063,49 +7071,48 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7113,17 +7120,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7148,42 +7144,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.2",
+ "windows-result",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7197,9 +7184,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -7276,6 +7263,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7440,7 +7436,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ ahash                  = "0.8"
 anyhow                 = "1"
 assert_matches         = "1.5.0"
 async-trait            = "0.1"
-aws-config             = "1.6.2"
+aws-config             = "1.6.3"
 aws-credential-types   = "1.2.3"
-aws-sdk-sqs            = "1.67.0"
-aws-sigv4              = "1.3.1"
+aws-sdk-sqs            = "1.70.0"
+aws-sigv4              = "1.3.2"
 aws-smithy-async       = "1.2.5"
 aws-smithy-http        = "0.62.1"
 aws-smithy-runtime-api = { version = "1.8.0", features = ["test-util"] }
@@ -40,11 +40,11 @@ bd-test-helpers        = { git = "https://github.com/bitdriftlabs/shared-core.gi
 bd-time                = { git = "https://github.com/bitdriftlabs/shared-core.git" }
 built                  = { version = "0.8", features = ["git2"] }
 bytes                  = "1"
-cc                     = "1.2.22"
-clap                   = { version = "4.5.38", features = ["derive", "env"] }
+cc                     = "1.2.24"
+clap                   = { version = "4.5.39", features = ["derive", "env"] }
 comfy-table            = "7.1.4"
 console-subscriber     = "0.4.1"
-criterion              = { version = "0.5", features = ["html_reports"] }
+criterion              = { version = "0.6", features = ["html_reports"] }
 ctor                   = "0.4.2"
 cuckoofilter           = "0.5.0"
 dashmap                = { version = "6", features = ["raw-api"] }
@@ -60,20 +60,20 @@ http-body-util         = "0.1.3"
 humantime-serde        = "1.1"
 hyper                  = "1.6.0"
 
-hyper-rustls = { version = "0.27.5", default-features = false, features = [
+hyper-rustls = { version = "0.27.6", default-features = false, features = [
   "http1",
   "http2",
   "webpki-tokio",
   "aws-lc-rs",
 ] }
 
-hyper-util            = { version = "0.1.11", features = ["client", "client-legacy"] }
+hyper-util            = { version = "0.1.13", features = ["client", "client-legacy"] }
 hyperloglogplus       = "0.4.1"
 intrusive-collections = "0.9.7"
 itertools             = "0.14.0"
-k8s-openapi           = { version = "0.24.0", features = ["v1_28"] }
+k8s-openapi           = { version = "0.25.0", features = ["v1_30"] }
 
-kube = { version = "0.99.0", features = [
+kube = { version = "1.1.0", features = [
   "runtime",
   "derive",
   "rustls-tls",
@@ -115,7 +115,7 @@ serde                      = { version = "1", features = ["derive"] }
 serde_json                 = "1"
 serde_yaml                 = "0.9.34"
 snap                       = "1"
-socket2                    = "0.5.9"
+socket2                    = "0.5.10"
 tempfile                   = "3.20"
 thiserror                  = "2"
 tikv-jemalloc-ctl          = "0.6.0"
@@ -130,7 +130,7 @@ topological-sort           = "0.2.2"
 tracing                    = "0.1.41"
 unwrap-infallible          = "0.1.5"
 url                        = "2.5.4"
-uuid                       = { version = "1.16.0", features = ["v4"] }
+uuid                       = { version = "1.17.0", features = ["v4"] }
 
 vrl = { git = "https://github.com/mattklein123/vrl.git", branch = "performance-20240826", default-features = false, features = [
   "compiler",

--- a/pulse-metrics/benches/carbon_parsing.rs
+++ b/pulse-metrics/benches/carbon_parsing.rs
@@ -5,9 +5,10 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use pulse_metrics::protos::carbon;
 use std::hash::{Hash, Hasher};
+use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {
   let line: bytes::Bytes = r#"new-york.power.usage 42422 123456 source=local-_-host.edu data-center_.="dc1 and dc2!@#$/%^&*()""#.into();

--- a/pulse-metrics/benches/elision.rs
+++ b/pulse-metrics/benches/elision.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use bd_server_stats::stats::Collector;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use elision::elision_config::emit_config::Emit_type;
 use elision::elision_config::{EmitConfig, ZeroElisionConfig};
 use pulse_metrics::filters::filter::DynamicMetricFilter;
@@ -18,6 +18,7 @@ use pulse_metrics::pipeline::processor::sampler::SamplerState;
 use pulse_metrics::pipeline::time::RealDurationJitter;
 use pulse_metrics::test::make_carbon_wire_protocol;
 use pulse_protobuf::protos::pulse::config::processor::v1::elision;
+use std::hint::black_box;
 use std::sync::Arc;
 use time::Duration;
 use time::ext::NumericalDuration;

--- a/pulse-metrics/src/admin/server.rs
+++ b/pulse-metrics/src/admin/server.rs
@@ -293,14 +293,11 @@ impl MetaStatsSender for PromRemoteWriteMetaStatsSender {
         {
           Ok(()) => Ok(()),
           Err(e) => {
-            let translated_e = Error::new(
-              ErrorKind::Other,
-              format!(
-                "request (size={}) failed: {}",
-                compressed_write_request.len(),
-                e
-              ),
-            );
+            let translated_e = Error::other(format!(
+              "request (size={}) failed: {}",
+              compressed_write_request.len(),
+              e
+            ));
             if should_retry(&e) {
               Err(backoff::Error::transient(translated_e))
             } else {

--- a/pulse-metrics/src/batch_test.rs
+++ b/pulse-metrics/src/batch_test.rs
@@ -30,6 +30,7 @@ const fn complete(size: usize) -> Option<TestBatchResult> {
   Some(TestBatchResult::Complete(size))
 }
 
+#[allow(clippy::single_option_map)]
 fn map_return(batches: Option<Vec<TestBatch>>) -> Option<Vec<Vec<&'static str>>> {
   batches.map(|b| b.into_iter().map(|b| b.items).collect())
 }

--- a/pulse-metrics/src/filters/filter.rs
+++ b/pulse-metrics/src/filters/filter.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::protos::metric::{Metric, MetricType, MetricValue};
+use crate::protos::metric::{MetricType, MetricValue, ParsedMetric};
 
 //
 // MetricFilterDecision
@@ -26,7 +26,7 @@ pub enum MetricFilterDecision {
 pub trait MetricFilter {
   fn decide(
     &self,
-    metric: &Metric,
+    metric: &ParsedMetric,
     last_value: &Option<MetricValue>,
     last_value_type: Option<MetricType>,
   ) -> MetricFilterDecision;
@@ -58,7 +58,7 @@ impl SimpleMetricFilter {
 impl MetricFilter for SimpleMetricFilter {
   fn decide(
     &self,
-    _: &Metric,
+    _: &ParsedMetric,
     _: &Option<MetricValue>,
     _: Option<MetricType>,
   ) -> MetricFilterDecision {

--- a/pulse-metrics/src/filters/fst_test.rs
+++ b/pulse-metrics/src/filters/fst_test.rs
@@ -8,16 +8,29 @@
 use super::*;
 use crate::filters::filter::MetricFilterDecision;
 use crate::filters::poll_filter::PollFilter;
-use crate::protos::metric::{Metric, MetricId, MetricValue};
+use crate::protos::metric::{
+  DownstreamId,
+  Metric,
+  MetricId,
+  MetricSource,
+  MetricValue,
+  ParsedMetric,
+};
 use bytes::Bytes;
 use fst::SetBuilder;
+use std::time::Instant;
 
-fn mock_metric(name: bytes::Bytes) -> Metric {
-  Metric::new(
-    MetricId::new(name, None, vec![], false).unwrap(),
-    None,
-    1_660_557_239,
-    MetricValue::Simple(0.),
+fn mock_metric(name: bytes::Bytes) -> ParsedMetric {
+  ParsedMetric::new(
+    Metric::new(
+      MetricId::new(name, None, vec![], false).unwrap(),
+      None,
+      1_660_557_239,
+      MetricValue::Simple(0.),
+    ),
+    MetricSource::Aggregation { prom_source: false },
+    Instant::now(),
+    DownstreamId::LocalOrigin,
   )
 }
 

--- a/pulse-metrics/src/filters/regex_test.rs
+++ b/pulse-metrics/src/filters/regex_test.rs
@@ -8,15 +8,28 @@
 use super::*;
 use crate::filters::filter::MetricFilterDecision;
 use crate::filters::poll_filter::PollFilter;
-use crate::protos::metric::{Metric, MetricId, MetricValue};
+use crate::protos::metric::{
+  DownstreamId,
+  Metric,
+  MetricId,
+  MetricSource,
+  MetricValue,
+  ParsedMetric,
+};
 use bytes::Bytes;
+use std::time::Instant;
 
-fn new_metric(name: bytes::Bytes) -> Metric {
-  Metric::new(
-    MetricId::new(name, None, vec![], false).unwrap(),
-    None,
-    1_660_557_239,
-    MetricValue::Simple(0.),
+fn new_metric(name: bytes::Bytes) -> ParsedMetric {
+  ParsedMetric::new(
+    Metric::new(
+      MetricId::new(name, None, vec![], false).unwrap(),
+      None,
+      1_660_557_239,
+      MetricValue::Simple(0.),
+    ),
+    MetricSource::Aggregation { prom_source: false },
+    Instant::now(),
+    DownstreamId::LocalOrigin,
   )
 }
 

--- a/pulse-metrics/src/filters/zero_test.rs
+++ b/pulse-metrics/src/filters/zero_test.rs
@@ -9,11 +9,14 @@ use crate::filters::filter::{MetricFilter, MetricFilterDecision};
 use crate::filters::zero::ZeroFilter;
 use crate::protos::metric::{
   CounterType,
+  DownstreamId,
   HistogramData,
   Metric,
   MetricId,
+  MetricSource,
   MetricType,
   MetricValue,
+  ParsedMetric,
   SummaryData,
 };
 use bytes::Bytes;
@@ -21,13 +24,19 @@ use elision_config::ZeroElisionConfig;
 use elision_config::zero_elision_config::counters::AbsoluteCounters;
 use elision_config::zero_elision_config::{Counters, Histograms};
 use pulse_protobuf::protos::pulse::config::processor::v1::elision::elision_config;
+use std::time::Instant;
 
-fn mock_metric(metric_value: MetricValue, mtype: Option<MetricType>) -> Metric {
-  Metric::new(
-    MetricId::new(Bytes::new(), mtype, vec![], false).unwrap(),
-    None,
-    1_660_557_239,
-    metric_value,
+fn mock_metric(metric_value: MetricValue, mtype: Option<MetricType>) -> ParsedMetric {
+  ParsedMetric::new(
+    Metric::new(
+      MetricId::new(Bytes::new(), mtype, vec![], false).unwrap(),
+      None,
+      1_660_557_239,
+      metric_value,
+    ),
+    MetricSource::PromRemoteWrite,
+    Instant::now(),
+    DownstreamId::LocalOrigin,
   )
 }
 

--- a/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
+++ b/pulse-metrics/src/pipeline/inflow/wire/pre_buffer.rs
@@ -56,7 +56,7 @@ impl PreBuffer {
 
   pub fn buffer(&mut self, metrics: Vec<ParsedMetric>) {
     for metric in metrics {
-      let (metric_id, sample_rate, _, value) = metric.into_metric().into_parts();
+      let (metric_id, sample_rate, _, value) = metric.into_metric().0.into_parts();
       let mtype = metric_id.mtype();
 
       // The hash for MetricKey and MetricId will be consistent. We do the following with hashbrown

--- a/pulse-metrics/src/pipeline/inflow/wire/util.rs
+++ b/pulse-metrics/src/pipeline/inflow/wire/util.rs
@@ -339,7 +339,7 @@ impl SocketHandler {
           Err(std::io::Error::new(ErrorKind::TimedOut, "read timeout"))
         }
         () = shutdown.cancelled() => {
-          Err(std::io::Error::new(ErrorKind::Other, "shutting down"))
+          Err(std::io::Error::other("shutting down"))
         }
         () = async {
           self.pre_buffer.as_mut().unwrap().sleep.as_mut().await;

--- a/pulse-metrics/src/pipeline/processor/elision/state.rs
+++ b/pulse-metrics/src/pipeline/processor/elision/state.rs
@@ -88,7 +88,7 @@ impl State {
 
   fn update(
     &mut self,
-    metric: &Metric,
+    metric: &ParsedMetric,
     metric_filters: &[DynamicMetricFilter],
   ) -> (FilterDecision, Option<usize>) {
     let (filter_decision, filter_index, saw_initializing) = metric_filters.iter().enumerate().fold(
@@ -112,9 +112,9 @@ impl State {
       },
     );
 
-    self.last_value = Some(metric.value.clone());
-    self.last_type = metric.get_id().mtype();
-    self.last_timestamp = metric.timestamp;
+    self.last_value = Some(metric.metric().value.clone());
+    self.last_type = metric.metric().get_id().mtype();
+    self.last_timestamp = metric.metric().timestamp;
 
     let seconds_since_last_emitted = self
       .last_timestamp
@@ -285,7 +285,7 @@ impl ElisionState {
     let mut state = state.lock();
     let (filter_decision, index) = {
       let _filter_time = self.stats.filter_time.start_timer();
-      state.update(metric.metric(), metric_filters)
+      state.update(metric, metric_filters)
     };
     let skip_decision = skip_decider.decide(metric.metric(), filter_decision, emit_override);
     state.update_last_elided_or_emitted(&skip_decision, metric.metric().timestamp);

--- a/pulse-protobuf/proto/pulse/config/outflow/v1/otlp.proto
+++ b/pulse-protobuf/proto/pulse/config/outflow/v1/otlp.proto
@@ -47,4 +47,11 @@ message OtlpClientConfig {
 
   // Compression to use. Defaults to SNAPPY.
   OtlpCompression compression = 9;
+
+  // If sending OTLP to a backend that expects Prometheus-style names, convert the metric names to
+  // Prometheus format:
+  // https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+  // For tags invalid characters will be replaced with '_'. For names, '.' will be replaced with ':'
+  // and other invalid characters will be replaced with '_'.
+  bool convert_names_to_prometheus = 10;
 }

--- a/pulse-protobuf/src/protos/pulse/config/outflow/v1/otlp.rs
+++ b/pulse-protobuf/src/protos/pulse/config/outflow/v1/otlp.rs
@@ -53,6 +53,8 @@ pub struct OtlpClientConfig {
     pub retry_policy: ::protobuf::MessageField<super::retry::RetryPolicy>,
     // @@protoc_insertion_point(field:pulse.config.outflow.v1.OtlpClientConfig.compression)
     pub compression: ::protobuf::EnumOrUnknown<otlp_client_config::OtlpCompression>,
+    // @@protoc_insertion_point(field:pulse.config.outflow.v1.OtlpClientConfig.convert_names_to_prometheus)
+    pub convert_names_to_prometheus: bool,
     // special fields
     // @@protoc_insertion_point(special_field:pulse.config.outflow.v1.OtlpClientConfig.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -70,7 +72,7 @@ impl OtlpClientConfig {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(9);
+        let mut fields = ::std::vec::Vec::with_capacity(10);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "send_to",
@@ -117,6 +119,11 @@ impl OtlpClientConfig {
             |m: &OtlpClientConfig| { &m.compression },
             |m: &mut OtlpClientConfig| { &mut m.compression },
         ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "convert_names_to_prometheus",
+            |m: &OtlpClientConfig| { &m.convert_names_to_prometheus },
+            |m: &mut OtlpClientConfig| { &mut m.convert_names_to_prometheus },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<OtlpClientConfig>(
             "OtlpClientConfig",
             fields,
@@ -162,6 +169,9 @@ impl ::protobuf::Message for OtlpClientConfig {
                 72 => {
                     self.compression = is.read_enum_or_unknown()?;
                 },
+                80 => {
+                    self.convert_names_to_prometheus = is.read_bool()?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -206,6 +216,9 @@ impl ::protobuf::Message for OtlpClientConfig {
         if self.compression != ::protobuf::EnumOrUnknown::new(otlp_client_config::OtlpCompression::SNAPPY) {
             my_size += ::protobuf::rt::int32_size(9, self.compression.value());
         }
+        if self.convert_names_to_prometheus != false {
+            my_size += 1 + 1;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -239,6 +252,9 @@ impl ::protobuf::Message for OtlpClientConfig {
         if self.compression != ::protobuf::EnumOrUnknown::new(otlp_client_config::OtlpCompression::SNAPPY) {
             os.write_enum(9, ::protobuf::EnumOrUnknown::value(&self.compression))?;
         }
+        if self.convert_names_to_prometheus != false {
+            os.write_bool(10, self.convert_names_to_prometheus)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -265,6 +281,7 @@ impl ::protobuf::Message for OtlpClientConfig {
         self.request_headers.clear();
         self.retry_policy.clear();
         self.compression = ::protobuf::EnumOrUnknown::new(otlp_client_config::OtlpCompression::SNAPPY);
+        self.convert_names_to_prometheus = false;
         self.special_fields.clear();
     }
 
@@ -279,6 +296,7 @@ impl ::protobuf::Message for OtlpClientConfig {
             request_headers: ::std::vec::Vec::new(),
             retry_policy: ::protobuf::MessageField::none(),
             compression: ::protobuf::EnumOrUnknown::from_i32(0),
+            convert_names_to_prometheus: false,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -372,7 +390,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x1a#pulse/config/common/v1/common.proto\x1a\"pulse/config/common/v1/ret\
     ry.proto\x1a*pulse/config/outflow/v1/queue_policy.proto\x1a,pulse/config\
     /outflow/v1/outflow_common.proto\x1a\x1egoogle/protobuf/duration.proto\
-    \x1a\x17validate/validate.proto\"\xb4\x05\n\x10OtlpClientConfig\x12\x20\
+    \x1a\x17validate/validate.proto\"\xf3\x05\n\x10OtlpClientConfig\x12\x20\
     \n\x07send_to\x18\x01\x20\x01(\tR\x06sendToB\x07\xfaB\x04r\x02\x10\x01\
     \x12L\n\x0frequest_timeout\x18\x02\x20\x01(\x0b2\x19.google.protobuf.Dur\
     ationR\x0erequestTimeoutB\x08\xfaB\x05\xaa\x01\x02*\0\x12'\n\rmax_in_fli\
@@ -385,9 +403,10 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     estHeaders\x12F\n\x0cretry_policy\x18\x08\x20\x01(\x0b2#.pulse.config.co\
     mmon.v1.RetryPolicyR\x0bretryPolicy\x12[\n\x0bcompression\x18\t\x20\x01(\
     \x0e29.pulse.config.outflow.v1.OtlpClientConfig.OtlpCompressionR\x0bcomp\
-    ression\"'\n\x0fOtlpCompression\x12\n\n\x06SNAPPY\x10\0\x12\x08\n\x04NON\
-    E\x10\x01B\x10\n\x0e_max_in_flightB\x14\n\x12_batch_max_samplesb\x06prot\
-    o3\
+    ression\x12=\n\x1bconvert_names_to_prometheus\x18\n\x20\x01(\x08R\x18con\
+    vertNamesToPrometheus\"'\n\x0fOtlpCompression\x12\n\n\x06SNAPPY\x10\0\
+    \x12\x08\n\x04NONE\x10\x01B\x10\n\x0e_max_in_flightB\x14\n\x12_batch_max\
+    _samplesb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/pulse-proxy/src/test/integration/mod.rs
+++ b/pulse-proxy/src/test/integration/mod.rs
@@ -627,7 +627,7 @@ impl OtlpClient {
   }
 
   async fn send(&self, metrics: Vec<ParsedMetric>) {
-    let write_request = finish_otlp_batch(metrics, OtlpCompression::NONE);
+    let write_request = finish_otlp_batch(metrics, OtlpCompression::NONE, false);
     self
       .client
       .send_write_request(write_request, None)

--- a/pulse-proxy/src/test/integration/otlp.rs
+++ b/pulse-proxy/src/test/integration/otlp.rs
@@ -49,6 +49,7 @@ OTLP_INFLOW = r#"
       otlp:
         otlp:
           send_to: "http://{fake_upstream}/v1/metrics"
+          convert_names_to_prometheus: true
   "#;
 }
 
@@ -82,13 +83,13 @@ async fn otlp() {
     .send(vec![
       make_metric("foo", &[], 1),
       make_gauge("bar", &[("hello", "world")], 2, 1.3),
-      make_abs_counter("baz", &[("hello1", "world1")], 3, 4.5),
+      make_abs_counter("baz.something", &[("hello1.blah", "world1")], 3, 4.5),
     ])
     .await;
   assert_eq!(
     vec![
       make_gauge("bar", &[("hello", "world")], 2, 1.3),
-      make_abs_counter("baz", &[("hello1", "world1")], 3, 4.5),
+      make_abs_counter("baz:something", &[("hello1_blah", "world1")], 3, 4.5),
       make_gauge("foo", &[], 1, 0.0),
     ],
     upstream.wait_for_metrics().await.1


### PR DESCRIPTION
Handle both names and labels.

Additionally, fix prom outflow conversion to convert labels as well as names. This fixes sending OTLP to AMP for example.

Fixes BIT-5431